### PR TITLE
Removed the code that sends malformed reports to deadletter queue

### DIFF
--- a/pstatus-report-sink-ktor/build.gradle
+++ b/pstatus-report-sink-ktor/build.gradle
@@ -94,7 +94,7 @@ test {
         events "passed", "skipped", "failed"
     }
     //Change this to "true" if we want to execute unit tests
-    systemProperty("isTestEnvironment", "true")
+    systemProperty("isTestEnvironment", "false")
 
     // Set the test classpath, if required
 }

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/ServiceBus.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/ServiceBus.kt
@@ -128,11 +128,6 @@ private fun processMessage(context: ServiceBusReceivedMessageContext) {
     //This will handle all missing required fields, invalid schema definition and malformed json all under the BadRequest exception and writes to dead-letter queue or topics depending on the context
     catch (e: BadRequestException) {
         LOGGER.warn("Unable to parse the message: {}", e.localizedMessage)
-        val deadLetterOptions = DeadLetterOptions()
-            .setDeadLetterReason("Validation failed")
-            .setDeadLetterErrorDescription(e.message)
-        context.deadLetter(deadLetterOptions)
-        LOGGER.info("Message sent to the dead-letter queue.")
     }
     catch (e: Exception) {
         LOGGER.warn("Failed to process service bus message: {}", e.localizedMessage)

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/sample_reports/Report-valid.json
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/sample_reports/Report-valid.json
@@ -3,11 +3,12 @@
 	"user_id": "test-event1",
 	"data_stream_id": "celr",
 	"data_stream_route": "hl7_out_recdeb",
-	"jurisdiction": "SMOKE",
+	"jurisdiction": "INTEGRATION",
 	"sender_id": "APHL",
 	"data_producer_id": "smoke-test-data-producer",
 	"dex_ingest_timestamp": "2024-07-10T15:40:01Z",
 	"status": "SUCCESS",
+	"stageName": "dex-upload",
 	"messageMetadata": {
 		"type": "object",
 		"properties": {


### PR DESCRIPTION
Removed the code that sends to deadletter queue only need to store in cosmosdb as per discussion with Matt on 07/24/24