### PR TITLE
Fixe duplicate report bug in CosmosDB dead-letter container

### DIFF
--- a/pstatus-report-sink-ktor/src/main/resources/application.conf
+++ b/pstatus-report-sink-ktor/src/main/resources/application.conf
@@ -14,10 +14,10 @@ ktor {
 
 azure {
     service_bus {
-        connection_string = ${SERVICE_BUS_CONNECTION_STRING}
-        queue_name = ${SERVICE_BUS_REPORT_QUEUE_NAME}
-        topic_name = ${SERVICE_BUS_REPORT_TOPIC_NAME}
-        subscription_name = ${SERVICE_BUS_REPORT_TOPIC_SUBSCRIPTION_NAME}
+        connection_string = ${?SERVICE_BUS_CONNECTION_STRING}
+        queue_name = ${?SERVICE_BUS_REPORT_QUEUE_NAME}
+        topic_name = ${?SERVICE_BUS_REPORT_TOPIC_NAME}
+        subscription_name = ${?SERVICE_BUS_REPORT_TOPIC_SUBSCRIPTION_NAME}
     }
     cosmos_db {
         client {
@@ -30,18 +30,18 @@ azure {
 }
 aws {
     sqs {
-        url = ${AWS_SQS_URL}
+        url = ${?AWS_SQS_URL}
     }
-    access_key_id = ${AWS_ACCESS_KEY_ID}
-    secret_access_key = ${AWS_SECRET_ACCESS_KEY}
-    region = ${AWS_REGION}
+    access_key_id = ${?AWS_ACCESS_KEY_ID}
+    secret_access_key = ${?AWS_SECRET_ACCESS_KEY}
+    region = ${?AWS_REGION}
 }
 
 rabbitMQ {
-    host = ${RABBITMQ_HOST}
-    port = ${RABBITMQ_PORT}
-    user_name = ${RABBITMQ_USERNAME}
-    password = ${RABBITMQ_PASSWORD}
-    queue_name = ${RABBITMQ_REPORT_QUEUE_NAME}
-    virtual_host = ${RABBITMQ_VIRTUAL_HOST}
+    host = ${?RABBITMQ_HOST}
+    port = ${?RABBITMQ_PORT}
+    user_name = ${?RABBITMQ_USERNAME}
+    password = ${?RABBITMQ_PASSWORD}
+    queue_name = ${?RABBITMQ_REPORT_QUEUE_NAME}
+    virtual_host = ${?RABBITMQ_VIRTUAL_HOST}
 }


### PR DESCRIPTION
-Fixed an issue where duplicate reports were being created in `CosmosDB` dead-letter container.
-`MSG_SYSTEM` is a required field, and made environment variables for `AZURE SERVICE BUS`, `RABBITMQ` and `AWS` optional.
-Renamed variable `malformedReportSBMessage`   to more generic `malformedReportMessage`. 