### PR TITLE
Add undeliveredUploads feature to UploadStats.

### DIFF
--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
@@ -152,9 +152,8 @@ class UploadStatsLoader: CosmosLoader() {
                         + "r.content.content_schema_name = 'blob-file-copy' and "
                         + "r.stageInfo.status = 'FAILURE' and "
                         + "$timeRangeWhereClause "
-                        + "group by r.uploadId"
                 )
-
+        logger.info("UploadsStats, fetch uploadIds query = $unDeliveredUploadIdsQuery")
 
         val unDeliveredUploadIdsResult = reportsContainer?.queryItems(
             unDeliveredUploadIdsQuery, CosmosQueryRequestOptions(),
@@ -171,9 +170,10 @@ class UploadStatsLoader: CosmosLoader() {
                         + "from r "
                         + "where r.dataStreamId = '$dataStreamId' and r.dataStreamRoute = '$dataStreamRoute' and "
                         + "r.stageInfo.action = 'metadata-verify' and "
-                        + "r.uploadId in ($quotedIds) "
+                        + "r.uploadId in ($quotedIds) and "
+                        + "$timeRangeWhereClause "
                 )
-
+        logger.info("UploadsStats, fetch undelivered uploads query = $unDeliveredUploadsQuery")
 
         val unDeliveredUploadsResult = reportsContainer?.queryItems(
             unDeliveredUploadsQuery, CosmosQueryRequestOptions(),

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/PendingUploadCounts.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/PendingUploadCounts.kt
@@ -1,0 +1,13 @@
+package gov.cdc.ocio.processingstatusapi.models.query
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+
+@GraphQLDescription("Collection of undelivered uploads found")
+data class PendingUploadCounts(
+
+    @GraphQLDescription("Total number of undelivered uploads.")
+    var totalCount: Long = 0,
+
+    @GraphQLDescription("Provides a list of all the uploads that have not been delivered. This means, the upload started, but according to the upload status reports we did not receive 100% of the expected chunks.")
+    var pendingUploads: List<UnDeliveredUpload> = listOf()
+)

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UnDeliveredUpload.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UnDeliveredUpload.kt
@@ -1,0 +1,13 @@
+package gov.cdc.ocio.processingstatusapi.models.query
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+
+@GraphQLDescription("Collection of undelivered found")
+data class UnDeliveredUpload(
+
+    @GraphQLDescription("UploadId of the file that is not delivered.")
+    var uploadId: String? = null,
+
+    @GraphQLDescription("Filename of the file that is not delivered.")
+    var filename: String? = null
+)

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UnDeliveredUploadCounts.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UnDeliveredUploadCounts.kt
@@ -1,0 +1,13 @@
+package gov.cdc.ocio.processingstatusapi.models.query
+
+import com.expediagroup.graphql.generator.annotations.GraphQLDescription
+
+@GraphQLDescription("Collection of undelivered uploads found")
+data class UnDeliveredUploadCounts(
+
+    @GraphQLDescription("Total number of undelivered uploads.")
+    var totalCount: Long = 0,
+
+    @GraphQLDescription("Provides a list of all the uploads that have not been delivered. This means, the upload started, but according to the upload status reports we did not receive 100% of the expected chunks.")
+    var unDeliveredUploads: List<UnDeliveredUpload> = listOf()
+)

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UploadStats.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UploadStats.kt
@@ -21,5 +21,8 @@ data class UploadStats(
     var completedUploadsCount: Long = 0,
 
     @GraphQLDescription("Provides a list of all the duplicate filenames that were uploaded and how many.")
-    var duplicateFilenames: List<DuplicateFilenameCounts> = listOf()
+    var duplicateFilenames: List<DuplicateFilenameCounts> = listOf(),
+
+    @GraphQLDescription("Provides a list of all the uploads that have not been delivered. This means, the upload started, but according to the upload status reports we did not receive 100% of the expected chunks.")
+    var unDeliveredUploads: UnDeliveredUploadCounts = UnDeliveredUploadCounts()
 )

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UploadStats.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/UploadStats.kt
@@ -24,5 +24,8 @@ data class UploadStats(
     var duplicateFilenames: List<DuplicateFilenameCounts> = listOf(),
 
     @GraphQLDescription("Provides a list of all the uploads that have not been delivered. This means, the upload started, but according to the upload status reports we did not receive 100% of the expected chunks.")
-    var unDeliveredUploads: UnDeliveredUploadCounts = UnDeliveredUploadCounts()
+    var unDeliveredUploads: UnDeliveredUploadCounts = UnDeliveredUploadCounts(),
+
+    @GraphQLDescription("Provides a list of all the uploads that are pending. This means, the upload started, but according to the upload status reports we did not receive 100% of the expected chunks.")
+    var pendingUploads: PendingUploadCounts = PendingUploadCounts()
 )

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/GraphQL.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/GraphQL.kt
@@ -102,7 +102,7 @@ fun Application.graphQLModule() {
                 NotificationsMutationService(),
                 DataStreamTopErrorsNotificationSubscriptionMutationService(),
                 DeadlineCheckSubscriptionMutationService(),
-                UploadErrorsNotificationSubscriptionMutationService()
+                UploadErrorsNotificationSubscriptionMutationService(),
                 ReportMutation()
 
             )

--- a/pstatus-graphql-ktor/src/main/resources/application.conf
+++ b/pstatus-graphql-ktor/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 ktor {
     deployment {
-        port = 8082
+        port = 8080
         host = 0.0.0.0
     }
 


### PR DESCRIPTION
Update the GetUploadStats query to search for and provide the response for "undelivered uploads" and the associated counts as part of the query response.