### PR TITLE
DASB-808: Add `retryWithBackoff` Function to AWS SQS plugin

### DIFF
--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/AWSSQS.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/AWSSQS.kt
@@ -149,7 +149,7 @@ fun Application.awsSQSModule() {
  *
  * @param numOfRetries The number of times to retry attempts. Default is 3.
  * @param baseDelay The initial delay between retries in milliseconds. Default is 1000 ms.
- * @param maxDelay The maximum delay between retries, in milliseconds. Default is 1700 ms.
+ * @param maxDelay The maximum delay between retries, in milliseconds. Default is 6000 ms.
  * @param block The block of code to be executed.
  *
  */
@@ -170,5 +170,6 @@ suspend fun<P> retryWithBackoff(
         }
     }
     //This is the last attempt, and if it fails again will throw an exception
+    SchemaValidation.logger.error("Last Attempt, if it fails again exception will be thrown")
     return block()
 }

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/AWSSQS.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/AWSSQS.kt
@@ -148,18 +148,18 @@ fun Application.awsSQSModule() {
  * until `maxDelay` is reached or specified number of retries is exhausted.
  *
  * @param numOfRetries The number of times to retry attempts. Default is 3.
- * @param initialDelay The initial delay between retries in milliseconds. Default is 1000 ms.
+ * @param baseDelay The initial delay between retries in milliseconds. Default is 1000 ms.
  * @param maxDelay The maximum delay between retries, in milliseconds. Default is 1700 ms.
  * @param block The block of code to be executed.
  *
  */
 suspend fun<P> retryWithBackoff(
     numOfRetries: Int = 3,
-    initialDelay:Long = 1000,
-    maxDelay: Long=1600,
+    baseDelay:Long = 1000,
+    maxDelay: Long = 6000,
     block:suspend()-> P
 ): P{
-    var currentDelay = initialDelay
+    var currentDelay = baseDelay
     repeat(numOfRetries) {
         try{
             return block()


### PR DESCRIPTION
This PR adds retry functionality to `AWS SQS` plugin for `report-sink` service, which retries a block of code with exponential backoff.  Some of the key details:

- The `retryWithBackoff` function executes block of code, retries multiple times if exceptions occur. The delay is increased between each retry until `maxDelay` is reached.
- The function is designed with generic type parameter `<P>`  to allow different types of responses from the block of code that is being executed. i.e  `DeleteMessageRequest` and `ReceiveMessageRequest` and maybe more in the future.
-  On the last retry, exception is thrown.
