### PR TITLE
Bug out of mem health check

### DIFF
--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCosmosDb.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCosmosDb.kt
@@ -1,5 +1,6 @@
 package gov.cdc.ocio.database.health
 
+import com.azure.cosmos.CosmosClient
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import gov.cdc.ocio.database.cosmos.CosmosClientManager
 import gov.cdc.ocio.database.cosmos.CosmosConfiguration
@@ -13,16 +14,14 @@ import org.koin.core.component.inject
  * Concrete implementation of the cosmosdb health check.
  */
 @JsonIgnoreProperties("koin")
-class HealthCheckCosmosDb : HealthCheckSystem("Cosmos DB"), KoinComponent {
-
-    private val cosmosConfiguration by inject<CosmosConfiguration>()
+class HealthCheckCosmosDb(private val cosmosClient: CosmosClient) : HealthCheckSystem("Cosmos DB"), KoinComponent {
 
     /**
      * Checks and sets cosmosDBHealth status
      */
     override fun doHealthCheck() {
         try {
-            if (isCosmosDBHealthy()) {
+            if (isCosmosDbHealthy()) {
                 status = HealthStatusType.STATUS_UP
             }
         } catch (ex: Exception) {
@@ -36,8 +35,9 @@ class HealthCheckCosmosDb : HealthCheckSystem("Cosmos DB"), KoinComponent {
      *
      * @return Boolean
      */
-    private fun isCosmosDBHealthy(): Boolean {
-        return if (CosmosClientManager.getCosmosClient(cosmosConfiguration.uri, cosmosConfiguration.authKey) == null)
+    private fun isCosmosDbHealthy(): Boolean {
+        val databaseResponse = cosmosClient.getDatabase("ProcessingStatus")
+        return if (databaseResponse == null)
             throw Exception("Failed to establish a CosmosDB client.")
         else
             true

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCosmosDb.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCosmosDb.kt
@@ -2,13 +2,9 @@ package gov.cdc.ocio.database.health
 
 import com.azure.cosmos.CosmosClient
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import gov.cdc.ocio.database.cosmos.CosmosClientManager
-import gov.cdc.ocio.database.cosmos.CosmosConfiguration
 import gov.cdc.ocio.types.health.HealthCheckSystem
 import gov.cdc.ocio.types.health.HealthStatusType
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
-
 
 /**
  * Concrete implementation of the cosmosdb health check.

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCouchbaseDb.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/HealthCheckCouchbaseDb.kt
@@ -13,12 +13,12 @@ import org.koin.core.component.inject
  * Concrete implementation of the couchbase health check.
  */
 @JsonIgnoreProperties("koin")
-class HealthCheckCouchbaseDb: HealthCheckSystem("Couchbase DB"), KoinComponent {
+class HealthCheckCouchbaseDb(private val couchbaseCluster: Cluster? = null) : HealthCheckSystem("Couchbase DB"), KoinComponent {
 
     private val config by inject<CouchbaseConfiguration>()
 
     // Lazily initialized Couchbase Cluster instance
-    private val cluster: Cluster by lazy {
+    private val defaultCluster: Cluster by lazy {
         Cluster.connect(config.connectionString, config.username, config.password)
     }
 
@@ -27,6 +27,7 @@ class HealthCheckCouchbaseDb: HealthCheckSystem("Couchbase DB"), KoinComponent {
      */
     override fun doHealthCheck() {
         try {
+            val cluster = couchbaseCluster ?: defaultCluster // Use injected or default cluster
             cluster.ping() // Perform a lightweight health check like a ping
             status = HealthStatusType.STATUS_UP
 

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/CosmosDbClientFactory.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/CosmosDbClientFactory.kt
@@ -1,0 +1,19 @@
+package gov.cdc.ocio.database.health.dbClientFactory
+
+import com.azure.cosmos.CosmosClient
+import com.azure.cosmos.CosmosClientBuilder
+
+/**
+ * Factory for creating and managing Cosmos DB clients.
+ */
+object CosmosDbClientFactory {
+    fun createClient(uri: String, authKey: String): CosmosClient {
+        return CosmosClientBuilder()
+            .endpoint(uri)
+            .key(authKey)
+            .gatewayMode()
+            //.preferredRegions(listOf("East US")) // Optional: specify preferred regions
+            .consistencyLevel(com.azure.cosmos.ConsistencyLevel.SESSION) // Example consistency level
+            .buildClient()
+    }
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/CouchbaseClusterFactory.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/CouchbaseClusterFactory.kt
@@ -1,0 +1,10 @@
+package gov.cdc.ocio.database.health.dbClientFactory
+
+import com.couchbase.client.java.Cluster
+import gov.cdc.ocio.database.couchbase.CouchbaseConfiguration
+
+object CouchbaseClusterFactory {
+    fun createCluster(config: CouchbaseConfiguration): Cluster {
+        return Cluster.connect(config.connectionString, config.username, config.password)
+    }
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/DynamoDbClientFactory.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/DynamoDbClientFactory.kt
@@ -1,0 +1,23 @@
+package gov.cdc.ocio.database.health.dbClientFactory
+
+import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import java.nio.file.Path
+
+/**
+ * Services call DynamoDbClientFactory.createDefaultClient() for a consistent client configuration.
+ */
+object DynamoDbClientFactory {
+    fun createClient(region: String, roleArn: String?, webIdentityTokenFile: String?): DynamoDbClient {
+        val credentialsProvider = WebIdentityTokenFileCredentialsProvider.builder()
+            .roleArn(roleArn)
+            .webIdentityTokenFile(webIdentityTokenFile?.let { Path.of(it) })
+            .build()
+
+        return DynamoDbClient.builder()
+            .region(Region.of(region))
+           // .credentialsProvider(credentialsProvider)
+            .build()
+    }
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/MongoDbClientFactory.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/MongoDbClientFactory.kt
@@ -1,0 +1,31 @@
+package gov.cdc.ocio.database.health.dbClientFactory
+
+import com.mongodb.ConnectionString
+import com.mongodb.MongoClientSettings
+import com.mongodb.ServerApi
+import com.mongodb.ServerApiVersion
+import com.mongodb.client.MongoClients
+import com.mongodb.client.MongoClient
+import gov.cdc.ocio.database.mongo.MongoConfiguration
+
+object MongoDbClientFactory {
+
+    /**
+     * Creates a MongoClient instance based on the provided configuration.
+     *
+     * @param config MongoConfiguration
+     * @return MongoClient
+     */
+    fun createClient(config: MongoConfiguration): MongoClient {
+        val serverApi = ServerApi.builder()
+            .version(ServerApiVersion.V1)
+            .build()
+
+        val settings = MongoClientSettings.builder()
+            .applyConnectionString(ConnectionString(config.connectionString))
+            .serverApi(serverApi)
+            .build()
+
+        return MongoClients.create(settings)
+    }
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbModules/DatabaseModules.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbModules/DatabaseModules.kt
@@ -1,0 +1,57 @@
+package gov.cdc.ocio.database.health.dbModules
+
+import gov.cdc.ocio.database.cosmos.CosmosConfiguration
+import gov.cdc.ocio.database.cosmos.CosmosRepository
+import gov.cdc.ocio.database.couchbase.CouchbaseConfiguration
+import gov.cdc.ocio.database.dynamo.DynamoRepository
+import gov.cdc.ocio.database.health.HealthCheckCosmosDb
+import gov.cdc.ocio.database.health.HealthCheckCouchbaseDb
+import gov.cdc.ocio.database.health.HealthCheckDynamoDb
+import gov.cdc.ocio.database.health.HealthCheckMongoDb
+import gov.cdc.ocio.database.health.dbClientFactory.CosmosDbClientFactory
+import gov.cdc.ocio.database.health.dbClientFactory.CouchbaseClusterFactory
+import gov.cdc.ocio.database.health.dbClientFactory.DynamoDbClientFactory
+import gov.cdc.ocio.database.health.dbClientFactory.MongoDbClientFactory
+import gov.cdc.ocio.database.mongo.MongoConfiguration
+import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
+import org.koin.dsl.module
+
+/**
+ * Koin modules for database configurations and repositories
+ */
+object DatabaseModules {
+
+    fun provideCosmosModule(uri: String, authKey: String) = module {
+        single { CosmosConfiguration(uri, authKey) }
+        single { CosmosDbClientFactory.createClient(uri, authKey) } // Create CosmosClient using the factory
+        single { HealthCheckCosmosDb(get()) } // Inject CosmosClient and CosmosConfiguration
+    }
+
+    fun provideCouchbaseModule(connectionString: String, username: String, password: String) = module {
+        single { CouchbaseConfiguration(connectionString, username, password) }
+        single { CouchbaseClusterFactory.createCluster(get()) } // Create Cluster using the factory
+        single { HealthCheckCouchbaseDb(get()) } // Inject Cluster into the health check
+    }
+
+    fun provideDynamoModule(dynamoTablePrefix: String, region: String, roleArn: String?, webIdentityTokenFile: String? ) = module {
+        single {
+            DynamoDbClientFactory.createClient(
+                region,
+                roleArn,
+                webIdentityTokenFile
+            )
+        }
+
+        // Inject DynamoDB client into the health check
+        single { HealthCheckDynamoDb(get()) }
+    }
+
+    // MongoDB Module
+    fun provideMongoModule(connectionString: String, databaseName: String) = module {
+        single { MongoConfiguration(connectionString, databaseName) }
+        single { MongoDbClientFactory.createClient(get()) } // Create MongoDB client using the factory
+        single { HealthCheckMongoDb(get(),get()) } // HealthCheckMongoDb depends on MongoConfiguration injected via Koin
+    }
+}
+
+

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbModules/DatabaseModules.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbModules/DatabaseModules.kt
@@ -1,9 +1,7 @@
 package gov.cdc.ocio.database.health.dbModules
 
 import gov.cdc.ocio.database.cosmos.CosmosConfiguration
-import gov.cdc.ocio.database.cosmos.CosmosRepository
 import gov.cdc.ocio.database.couchbase.CouchbaseConfiguration
-import gov.cdc.ocio.database.dynamo.DynamoRepository
 import gov.cdc.ocio.database.health.HealthCheckCosmosDb
 import gov.cdc.ocio.database.health.HealthCheckCouchbaseDb
 import gov.cdc.ocio.database.health.HealthCheckDynamoDb
@@ -13,7 +11,6 @@ import gov.cdc.ocio.database.health.dbClientFactory.CouchbaseClusterFactory
 import gov.cdc.ocio.database.health.dbClientFactory.DynamoDbClientFactory
 import gov.cdc.ocio.database.health.dbClientFactory.MongoDbClientFactory
 import gov.cdc.ocio.database.mongo.MongoConfiguration
-import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import org.koin.dsl.module
 
 /**

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
@@ -6,11 +6,13 @@ import gov.cdc.ocio.database.cosmos.CosmosRepository
 import gov.cdc.ocio.database.couchbase.CouchbaseConfiguration
 import gov.cdc.ocio.database.couchbase.CouchbaseRepository
 import gov.cdc.ocio.database.dynamo.DynamoRepository
+import gov.cdc.ocio.database.health.dbModules.DatabaseModules
 import gov.cdc.ocio.database.mongo.MongoConfiguration
 import gov.cdc.ocio.database.mongo.MongoRepository
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import io.ktor.server.application.*
 import mu.KotlinLogging
+import org.koin.core.context.loadKoinModules
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -86,6 +88,42 @@ class DatabaseKoinCreator {
                 single { databaseType } // add databaseType to Koin Modules
             }
             return databaseModule
+        }
+
+        /**
+         *  Set the appropriate database module
+         *  Creates a koin module and injects singletons for the database config specified in the [ApplicationEnvironment]
+         *  @param environment ApplicationEnvironment
+         * @return [Module] Resultant koin module.
+         */
+        fun dbHealthCheckModuleFromAppEnv(environment: ApplicationEnvironment):Module {
+            val logger = KotlinLogging.logger {}
+            val database = environment.config.property("ktor.database").getString()
+            val databaseType = DatabaseType.UNKNOWN
+            when (database.lowercase()) {
+                DatabaseType.COSMOS.value ->
+                  return  DatabaseModules.provideCosmosModule(
+                    uri = environment.config.property("azure.cosmos_db.client.endpoint").getString(),
+                    authKey = environment.config.property("azure.cosmos_db.client.key").getString()
+                )
+                DatabaseType.COUCHBASE.value -> return DatabaseModules.provideCouchbaseModule(
+                    connectionString = environment.config.property("couchbase.connection_string").getString(),
+                    username = environment.config.property("couchbase.username").getString(),
+                    password = environment.config.property("couchbase.password").getString()
+                )
+                DatabaseType.DYNAMO.value ->return DatabaseModules.provideDynamoModule(
+                    dynamoTablePrefix = environment.config.property("aws.dynamo.table_prefix").getString(),
+                    region = environment.config.property("aws.region").getString(),
+                    roleArn = environment.config.property("aws.role_arn").getString(),
+                    webIdentityTokenFile =environment.config.property("aws.web_identity_token_file").getString()
+                )
+                DatabaseType.MONGO.value ->return DatabaseModules.provideMongoModule(
+                     connectionString = environment.config.property("mongo.connection_string").getString(),
+                     databaseName = environment.config.property("mongo.database_name").getString()
+                )
+                else -> logger.error("Unsupported database requested: $databaseType")
+            }
+           return module { single { DatabaseType.UNKNOWN } }
         }
     }
 }

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
@@ -16,8 +16,8 @@ import org.koin.ktor.plugin.Koin
 
 fun KoinApplication.loadKoinModules(environment: ApplicationEnvironment): KoinApplication {
     val databaseModule = DatabaseKoinCreator.moduleFromAppEnv(environment)
-
-    return modules(listOf(databaseModule))
+    val healthCheckDatabaseModule = DatabaseKoinCreator.dbHealthCheckModuleFromAppEnv(environment)
+    return modules(listOf(databaseModule, healthCheckDatabaseModule))
 }
 
 fun main(args: Array<String>) {

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/queries/HealthQueryService.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/queries/HealthQueryService.kt
@@ -76,10 +76,10 @@ class HealthCheckService: KoinComponent {
 
         val time = measureTimeMillis {
             databaseHealthCheck = when (databaseType) {
-                DatabaseType.COSMOS -> HealthCheckCosmosDb()
-                DatabaseType.MONGO -> HealthCheckMongoDb()
-                DatabaseType.COUCHBASE -> HealthCheckCouchbaseDb()
-                DatabaseType.DYNAMO -> HealthCheckDynamoDb()
+                DatabaseType.COSMOS -> getKoin().get<HealthCheckCosmosDb>()
+                DatabaseType.MONGO -> getKoin().get<HealthCheckMongoDb>()
+                DatabaseType.COUCHBASE -> getKoin().get<HealthCheckCouchbaseDb>()
+                DatabaseType.DYNAMO -> getKoin().get<HealthCheckDynamoDb>()
                 else -> HealthCheckUnsupportedDb()
             }
             databaseHealthCheck.doHealthCheck()

--- a/pstatus-graphql-ktor/src/main/resources/application.conf
+++ b/pstatus-graphql-ktor/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 ktor {
     deployment {
-        port = 8082
+        port = 8080
         host = 0.0.0.0
     }
 

--- a/pstatus-graphql-ktor/src/main/resources/application.conf
+++ b/pstatus-graphql-ktor/src/main/resources/application.conf
@@ -1,6 +1,6 @@
 ktor {
     deployment {
-        port = 8080
+        port = 8082
         host = 0.0.0.0
     }
 
@@ -25,9 +25,18 @@ jwt {
 }
 
 aws {
+    sqs {
+        url = ${?AWS_SQS_URL}
+    }
     dynamo {
         table_prefix = ${?DYNAMO_TABLE_PREFIX}
     }
+    access_key_id = ${?AWS_ACCESS_KEY_ID}
+    secret_access_key = ${?AWS_SECRET_ACCESS_KEY}
+    region = ${?AWS_REGION}
+    endpoint = ${?AWS_ENDPOINT_URL}
+    role_arn=${?AWS_ROLE_ARN}
+    web_identity_token_file=${?AWS_WEB_IDENTITY_TOKEN_FILE}
 }
 
 azure {

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/Application.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/Application.kt
@@ -16,6 +16,7 @@ import org.koin.ktor.plugin.Koin
 
 fun KoinApplication.loadKoinModules(environment: ApplicationEnvironment): KoinApplication {
     val databaseModule = DatabaseKoinCreator.moduleFromAppEnv(environment)
+    val healthCheckDatabaseModule = DatabaseKoinCreator.dbHealthCheckModuleFromAppEnv(environment)
     val temporalConfigModule = module {
         single {
             val appConfig: ApplicationConfig = get()
@@ -23,7 +24,7 @@ fun KoinApplication.loadKoinModules(environment: ApplicationEnvironment): KoinAp
             appConfig.property("temporal.temporal_service_target").getString())
         }
     }
-    return modules(listOf(databaseModule, temporalConfigModule, module {single{environment.config}}))
+    return modules(listOf(databaseModule, healthCheckDatabaseModule, temporalConfigModule, module {single{environment.config}}))
 }
 
 

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/HealthCheck.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/HealthCheck.kt
@@ -70,9 +70,10 @@ class HealthCheckService : KoinComponent {
 
         val time = measureTimeMillis {
             databaseHealthCheck = when (databaseType) {
-                DatabaseType.COSMOS -> HealthCheckCosmosDb()
-                DatabaseType.DYNAMO -> HealthCheckDynamoDb()
-                DatabaseType.COUCHBASE -> HealthCheckCouchbaseDb()
+                DatabaseType.COSMOS -> getKoin().get<HealthCheckCosmosDb>()
+                DatabaseType.MONGO -> getKoin().get<HealthCheckMongoDb>()
+                DatabaseType.COUCHBASE -> getKoin().get<HealthCheckCouchbaseDb>()
+                DatabaseType.DYNAMO -> getKoin().get<HealthCheckDynamoDb>()
                 else -> HealthCheckUnsupportedDb()
             }
             databaseHealthCheck.doHealthCheck()

--- a/pstatus-notifications-workflow-ktor/src/main/resources/application.conf
+++ b/pstatus-notifications-workflow-ktor/src/main/resources/application.conf
@@ -32,6 +32,8 @@ aws {
   access_key_id = ${?AWS_ACCESS_KEY_ID}
   secret_access_key = ${?AWS_SECRET_ACCESS_KEY}
   region = ${?AWS_REGION}
+  role_arn=${?AWS_ROLE_ARN}
+  web_identity_token_file=${?AWS_WEB_IDENTITY_TOKEN_FILE}
 }
 
 couchbase {

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
@@ -26,7 +26,7 @@ enum class MessageSystem {
  */
 fun KoinApplication.loadKoinModules(environment: ApplicationEnvironment): KoinApplication {
     val databaseModule = DatabaseKoinCreator.moduleFromAppEnv(environment)
-
+    val healthCheckDatabaseModule = DatabaseKoinCreator.dbHealthCheckModuleFromAppEnv(environment)
     val messageSystemModule = module {
         val msgType = environment.config.property("ktor.message_system").getString()
         single {msgType} // add msgType to Koin Modules
@@ -51,7 +51,7 @@ fun KoinApplication.loadKoinModules(environment: ApplicationEnvironment): KoinAp
         }
     }
 
-    return modules(listOf(databaseModule, messageSystemModule))
+    return modules(listOf(databaseModule,healthCheckDatabaseModule, messageSystemModule))
 }
 
 /**

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/health/HealthQueryService.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/health/HealthQueryService.kt
@@ -41,10 +41,10 @@ class HealthQueryService: KoinComponent {
 
         val time = measureTimeMillis {
             databaseHealthCheck = when (databaseType) {
-                DatabaseType.COSMOS -> HealthCheckCosmosDb()
-                DatabaseType.MONGO -> HealthCheckMongoDb()
-                DatabaseType.COUCHBASE -> HealthCheckCouchbaseDb()
-                DatabaseType.DYNAMO -> HealthCheckDynamoDb()
+                DatabaseType.COSMOS -> getKoin().get<HealthCheckCosmosDb>()
+                DatabaseType.MONGO -> getKoin().get<HealthCheckMongoDb>()
+                DatabaseType.COUCHBASE -> getKoin().get<HealthCheckCouchbaseDb>()
+                DatabaseType.DYNAMO -> getKoin().get<HealthCheckDynamoDb>()
                 else -> HealthCheckUnsupportedDb()
             }
             databaseHealthCheck.doHealthCheck()

--- a/pstatus-report-sink-ktor/src/main/resources/application.conf
+++ b/pstatus-report-sink-ktor/src/main/resources/application.conf
@@ -40,6 +40,8 @@ aws {
     secret_access_key = ${?AWS_SECRET_ACCESS_KEY}
     region = ${?AWS_REGION}
     endpoint = ${?AWS_ENDPOINT_URL}
+    role_arn=${?AWS_ROLE_ARN}
+    web_identity_token_file=${?AWS_WEB_IDENTITY_TOKEN_FILE}
 }
 
 rabbitMQ {


### PR DESCRIPTION
To make HealthCheckDynamoDb reusable whileaddressing the out-of-memory issue, injecting the DynamoDbClient instance into HealthCheckDynamoDb. This will allow the services and not the library to manage the lifecycle of the client.