### PR TITLE
As a result of switching the auth to WebIdentityTokenFileCredentialsProvider

### DIFF
--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/DynamoDbClientFactory.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/health/dbClientFactory/DynamoDbClientFactory.kt
@@ -1,5 +1,6 @@
 package gov.cdc.ocio.database.health.dbClientFactory
 
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.WebIdentityTokenFileCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
@@ -10,14 +11,26 @@ import java.nio.file.Path
  */
 object DynamoDbClientFactory {
     fun createClient(region: String, roleArn: String?, webIdentityTokenFile: String?): DynamoDbClient {
-        val credentialsProvider = WebIdentityTokenFileCredentialsProvider.builder()
+      /*  val credentialsProvider = WebIdentityTokenFileCredentialsProvider.builder()
             .roleArn(roleArn)
             .webIdentityTokenFile(webIdentityTokenFile?.let { Path.of(it) })
-            .build()
+            .build()*/
+
+        val credentialsProvider =    if (roleArn.isNullOrEmpty() ||
+            webIdentityTokenFile.isNullOrEmpty()) {
+            // Fallback to default credentials provider (access key and secret)
+            DefaultCredentialsProvider.create()
+        } else {
+            // Use Web Identity Token
+            WebIdentityTokenFileCredentialsProvider.builder()
+                .roleArn(roleArn)
+                .webIdentityTokenFile(webIdentityTokenFile.let { Path.of(it) })
+                .build()
+        }
 
         return DynamoDbClient.builder()
             .region(Region.of(region))
-           // .credentialsProvider(credentialsProvider)
+            .credentialsProvider(credentialsProvider)
             .build()
     }
 }

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
@@ -12,7 +12,6 @@ import gov.cdc.ocio.database.mongo.MongoRepository
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import io.ktor.server.application.*
 import mu.KotlinLogging
-import org.koin.core.context.loadKoinModules
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -77,8 +76,10 @@ class DatabaseKoinCreator {
 
                     DatabaseType.DYNAMO.value -> {
                         val dynamoTablePrefix = environment.config.property("aws.dynamo.table_prefix").getString()
+                        val roleArn = environment.config.property("aws.role_arn").getString()
+                        val webIdentityTokenFile = environment.config.property("aws.web_identity_token_file").getString()
                         single<ProcessingStatusRepository>(createdAtStart = true) {
-                            DynamoRepository(dynamoTablePrefix)
+                            DynamoRepository(dynamoTablePrefix,roleArn,webIdentityTokenFile)
                         }
                         databaseType = DatabaseType.DYNAMO
                     }


### PR DESCRIPTION
The local development for dynamodb configuration is no longer possible since the apps are looking for a token file set within the EKS pod. This story is to handle both forms of authentication so that apps can be run locally with aws cli credentials and in EKS by assuming the service account role.

The implementation first checks for the presence of the web identity token and if that fails, try the access key and token method.