### PR TITLE
add awssdk sts dependency to fix class not found error

### DIFF
--- a/pstatus-graphql-ktor/build.gradle
+++ b/pstatus-graphql-ktor/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation "io.ktor:ktor-client-logging:2.1.0"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0"
     implementation("com.fasterxml.jackson.core:jackson-databind:2.18.2")
+    implementation "software.amazon.awssdk:sts:2.29.34"
 
     implementation project(':libs:commons-database')
     implementation project(':libs:commons-types')


### PR DESCRIPTION
Added aws sdk sts package dependency to fix classpath error when using web identity token file credentials provider.