### PR TITLE
adding support for AWS short-term creds

### DIFF
--- a/test/scripts/.env
+++ b/test/scripts/.env
@@ -16,8 +16,7 @@ rabbitmq_queue_name="PSAPIQueue"
 rabbitmq_routing_key="psapi1234"
 
 # AWS Configuration (If using aws)
-aws_access_key_id="{{value}}"
-aws_secret_access_key="{{value}}"
+# Use cloudtamer short-term access keys exported to the environment or copied into a default profile in ~/.aws/credentials
 aws_region="{{value}}"
 aws_queue_url="{{value}}"
 aws_topic_arn="{{value}}"

--- a/test/scripts/load-testing/README.md
+++ b/test/scripts/load-testing/README.md
@@ -34,9 +34,11 @@ For Azure Service Bus only, set the following environment variables:
 - `azure_topic_name` - Your service bus topic name.
   
 #### AWS 
-For AWS SNS/SQS only, set the following environment variables:
-- `aws_access_key_id` - The Access Key ID for an IAM user with permissions to receive and delete messages from specified SQS queue.
-- `aws_secret_access_key` - The secret access key for an IAM user with permissions to receive and delete messages from the specified SQS queue. This key is used for authentication and secure access to the queue.
+For AWS SNS/SQS only, set the following variables in the OS environment or put in the default profile in ~/.aws/credentials:
+- `AWS_ACCESS_KEY_ID` - The Access Key ID for an IAM user with permissions to receive and delete messages from specified SQS queue.
+- `AWS_SECRET_ACCESS_KEY` - The secret access key for an IAM user with permissions to receive and delete messages from the specified SQS queue. This key is used for authentication and secure access to the queue.
+- `AWS_SESSION_TOKEN` - The session token, required when using short-term access keys.
+Set the remaining variables in the environment file:
 - `aws_region` - The AWS region where your SQS queue is located.
 - `aws_queue_url` - URL of the Amazon Simple Queue Service(SQS) queue.
 - `aws_topic_arn` - Value of the Amazon Simple Notification Service(SNS) topic.

--- a/test/scripts/load-testing/pstatus_load_test.py
+++ b/test/scripts/load-testing/pstatus_load_test.py
@@ -191,14 +191,10 @@ class AWSSystem(MessageSystem):
         self.use_queue = config.get('use_queue', 'true').lower() == 'true'
         self.sqs = boto3.client(
             'sqs',
-            aws_access_key_id=config['aws_access_key_id'],
-            aws_secret_access_key=config['aws_secret_access_key'],
             region_name=config['aws_region']
         )
         self.sns = boto3.client(
             'sns',
-            aws_access_key_id=config['aws_access_key_id'],
-            aws_secret_access_key=config['aws_secret_access_key'],
             region_name=config['aws_region']
         )
         self.queue_url = config['aws_queue_url']

--- a/test/scripts/load-testing/test_aws_connection.py
+++ b/test/scripts/load-testing/test_aws_connection.py
@@ -18,8 +18,6 @@ def test_aws_connection():
         # Create SQS client using config values
         sqs = boto3.client(
             'sqs',
-            aws_access_key_id=config['aws_access_key_id'],
-            aws_secret_access_key=config['aws_secret_access_key'],
             region_name=config['aws_region']
         )
 


### PR DESCRIPTION
Moved configuration of AWS creds to be picked up from the default locations (environment vars, or default credentials file), so it can be more easily set from cloudtamer exports.
NOTE: Short-term creds also require the AWS_SESSION_TOKEN to be set, which is also exported by cloudtamer.