### PR TITLE
Phdo 606 update gradle kotlin plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    kotlin("jvm") version "2.1.10" apply false
+}

--- a/event-reader-sink/build.gradle
+++ b/event-reader-sink/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.24'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'io.ktor.plugin' version '2.3.11'
 }
 apply plugin: "java"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.java.installations.auto-download=true
+kotlin_version=2.1.10

--- a/libs/commons-database/build.gradle
+++ b/libs/commons-database/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.23'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'java-library'
 }
 

--- a/libs/commons-database/gradle.properties
+++ b/libs/commons-database/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-kotlin_version=1.9.24
+kotlin_version=2.1.10
 logback_version=1.4.14

--- a/libs/commons-types/build.gradle
+++ b/libs/commons-types/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.23'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'java-library'
 }
 

--- a/libs/commons-types/gradle.properties
+++ b/libs/commons-types/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
-kotlin_version=1.9.24
+kotlin_version=2.1.10
 logback_version=1.4.14

--- a/libs/message-system/build.gradle
+++ b/libs/message-system/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '2.0.20'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
 }
 
 group = "gov.cdc.ocio"

--- a/libs/message-system/gradle.properties
+++ b/libs/message-system/gradle.properties
@@ -1,0 +1,1 @@
+kotlin_version=2.1.10

--- a/libs/schema-validation/build.gradle.kts
+++ b/libs/schema-validation/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id ("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id ("org.jetbrains.kotlin.jvm") version "2.1.10"
     id ("java-library")
     id ("io.ktor.plugin") version "2.3.11"
 }

--- a/libs/schema-validation/src/test/kotlin/test/CloudSchemaLoaderBlobTest.kt
+++ b/libs/schema-validation/src/test/kotlin/test/CloudSchemaLoaderBlobTest.kt
@@ -19,7 +19,7 @@ class CloudSchemaLoaderBlobTest {
         `when`(mockBlobClient.getSchemaFile(fileName)).thenReturn(mockContent)
 
         val config = mapOf(
-            "REPORT_SCHEMA_BLOB_CONNECTION_STR" to "fake-connection-string",
+            "REPORT_SCHEMA_BLOB_CONNECTION_STR" to "DefaultEndpointsProtocol=https;AccountName=test;AccountKey=test",
             "REPORT_SCHEMA_BLOB_CONTAINER" to "test-container"
         )
         val loader = CloudSchemaLoader("blob_storage", config)

--- a/libs/schema-validation/src/test/kotlin/test/ReportSchemaValidationTests.kt
+++ b/libs/schema-validation/src/test/kotlin/test/ReportSchemaValidationTests.kt
@@ -165,8 +165,7 @@ class ReportSchemaValidationTests {
         val testMessage =File("./src/test/kotlin/data/report_schema_contentSchemaVersion_validation.json").readBytes()
         val message = createMessageFromBinary(testMessage)
         val result: ValidationSchemaResult = schemaValidationService.validateJsonSchema(message)
-        val missingContent ="Report rejected: file - hl7v2-debatch.2.0.0.schema.json not found for content schema."
-        //"Report rejected: file: ${file.absolutePath} not found for content schema"
+        val missingContent ="Report rejected: Content schema file not found for content schema name 'hl7v2-debatch' and schema version '2.0.0'."
         Assert.assertTrue(!result.status)
         Assert.assertEquals(result.reason,missingContent)
         Assert.assertNotSame(result.invalidData, mutableListOf<String>())

--- a/libs/subscription-management/build.gradle.kts
+++ b/libs/subscription-management/build.gradle.kts
@@ -2,7 +2,7 @@
 
 
 plugins {
-    id ("org.jetbrains.kotlin.jvm") version "1.9.23"
+    id ("org.jetbrains.kotlin.jvm") version "2.1.10"
     id ("java-library")
 }
 
@@ -17,12 +17,12 @@ tasks.register("prepareKotlinBuildScriptModel"){}
 
 dependencies {
     implementation(kotlin("stdlib"))
-  //  implementation ("io.ktor:ktor-serialization-jackson:1.9.24")
+  //  implementation ("io.ktor:ktor-serialization-jackson:2.1.10")
     implementation("io.insert-koin:koin-core:3.4.0") // Add this if missing
     implementation(project(":libs:commons-database"))
-    implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.9.23")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
-    implementation ("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.23")
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib:2.1.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.10")
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.1.10")
     implementation ("com.sun.activation:javax.activation:1.2.0")
     implementation ("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
     implementation("com.networknt:json-schema-validator:1.0.73")
@@ -33,7 +33,7 @@ dependencies {
     implementation ("ch.qos.logback.contrib", "logback-json-classic", "0.1.5")
     implementation ("ch.qos.logback.contrib", "logback-jackson", "0.1.5")
     testImplementation(kotlin("test"))
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:1.9.23")
+    testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.1.10")
 }
 
 tasks.test {

--- a/pstatus-graphql-ktor/build.gradle
+++ b/pstatus-graphql-ktor/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.24'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'io.ktor.plugin' version '2.3.11'
     id "org.jetbrains.kotlin.plugin.serialization" version "1.8.20"
     id "com.gorylenko.gradle-git-properties" version "2.4.2"

--- a/pstatus-notifications-rules-engine-ktor/build.gradle
+++ b/pstatus-notifications-rules-engine-ktor/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.24'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'io.ktor.plugin' version '2.3.11'
     id("com.google.cloud.tools.jib") version "3.3.0" // Add Jib plugin
     id "maven-publish"

--- a/pstatus-notifications-rules-engine-ktor/gradle.properties
+++ b/pstatus-notifications-rules-engine-ktor/gradle.properties
@@ -1,4 +1,4 @@
 ktor_version=2.3.10
-kotlin_version=1.9.24
+kotlin_version=2.1.10
 logback_version=1.4.14
 kotlin.code.style=official

--- a/pstatus-notifications-workflow-ktor/build.gradle.kts
+++ b/pstatus-notifications-workflow-ktor/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
 }
 
 plugins {
-    kotlin("jvm") version "1.9.23"
+    kotlin("jvm") version "2.1.10"
     id("com.google.cloud.tools.jib") version "3.3.0"
     id ("io.ktor.plugin") version "2.3.11"
     id ("maven-publish")

--- a/pstatus-notifications-workflow-ktor/gradle.properties
+++ b/pstatus-notifications-workflow-ktor/gradle.properties
@@ -1,5 +1,5 @@
 ktor_version=2.3.10
-kotlin_version=1.9.24
+kotlin_version=2.1.10
 logback_version=1.4.14
 kotlin.code.style=official
 kotlinxHtmlVersion=0.12.0

--- a/pstatus-report-sink-ktor/build.gradle
+++ b/pstatus-report-sink-ktor/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.24'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'io.ktor.plugin' version '2.3.11'
     id "com.gorylenko.gradle-git-properties" version "2.4.2"
 }

--- a/pstatus-report-sink-ktor/gradle.properties
+++ b/pstatus-report-sink-ktor/gradle.properties
@@ -1,4 +1,4 @@
 ktor_version=2.3.10
-kotlin_version=1.9.24
+kotlin_version=2.1.10
 logback_version=1.4.14
 kotlin.code.style=official

--- a/spikes/event-reader-sink/build.gradle
+++ b/spikes/event-reader-sink/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 }
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '1.9.24'
+    id 'org.jetbrains.kotlin.jvm' version "$kotlin_version"
     id 'io.ktor.plugin' version '2.3.11'
 }
 apply plugin: "java"


### PR DESCRIPTION
Configures all modules to use kotlin plugin version 2.1.10 instead of a mix of versions, and does not apply the plugin at the root level. This is to avoid the error message below seen when running the gradle jib task in the current develop branch:

The Kotlin Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.
This might happen in subprojects that apply the Kotlin plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.
Please add the Kotlin plugin to the common parent project or the root project, then remove the versions in the subprojects.
If the parent project does not need the plugin, add 'apply false' to the plugin line.
See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl
The Kotlin plugin was loaded in the following projects: ':pstatus-notifications-rules-engine-ktor', ':pstatus-report-sink-ktor'

Running jib in this PR branch does not trigger the above error message.
