### PR TITLE
Updating getReport tests 

### DIFF
--- a/test/playwright/fixtures/dataGenerator.ts
+++ b/test/playwright/fixtures/dataGenerator.ts
@@ -1,29 +1,61 @@
 import { faker } from "@faker-js/faker"
 
-const baseReport = {
-    report_schema_version: "1.0.0",
-    upload_id: "uploadID",
-    user_id: "test-user",
-    data_stream_id: "dextesting",
-    data_stream_route: "testevent1",
-    jurisdiction: "jurisdiction",
-    sender_id: "sender",
-    data_producer_id: "dataproducer",
-    dex_ingest_datetime: "2025-03-06T14:21:28Z",
-    message_metadata: {
-        message_uuid: "uuid",
-        message_hash: 'messagehash',
-        aggregation: "SINGLE",
-        message_index: 1
-    },
-    tags: { tag_field1: "value1" },
-    data: { data_field1: "value1" },
-    content_type: "application/json",
-    content: {
-        content_schema_name: "upload-completed",
-        content_schema_version: "1.0.0",
-        status: "SUCCESS"
-    }
+export type UploadReport = {
+    report_schema_version: string,
+    upload_id: string,
+    user_id: string,
+    data_stream_id: string,
+    data_stream_route: string,
+    dex_ingest_datetime: string,
+    sender_id: string,
+    stage_info: StageInfo
+    content_type: string,
+    message_metadata?: MessageMetadata,
+    tags?: object,
+    data?: object,
+    jurisdiction?: string
+    data_producer_id?: string,
+    content: ContentUploadCompleted|ContentUploadStarted|ContentUploadStatus
+
+}
+
+export type ContentUploadCompleted = {
+    content_schema_name: string
+    content_schema_version: string
+    status: Status
+}
+
+export type ContentUploadStarted = {
+    content_schema_name: string
+    content_schema_version: string
+    status: Status
+}
+
+export type ContentUploadStatus = {
+    content_schema_name: string
+    content_schema_version: string
+    tguid: string
+    offset: number
+    size: number
+    filename: string
+}
+enum Aggregation {SINGLE="SINGLE", BATCH="BATCH"}
+enum Status {SUCCESS="SUCCESS", FAILURE="FAILURE"}
+type MessageMetadata = {
+    message_uuid: string,
+    message_hash: string,
+    aggregation: Aggregation,
+    message_index: number
+}
+
+type StageInfo = {
+    service: string
+    action: string
+    status: Status
+    start_processing_time: string
+    end_processing_time: string
+    version?: string
+    issues?: [any]
 }
 
 const minimalReport = {
@@ -32,12 +64,11 @@ const minimalReport = {
     data_stream_route: "testevent1",
     content_type: "application/json",
     content: {
-        content_schema_name: "upload-completed",
+        content_schema_name: "upload-started",
         content_schema_version: "1.0.0",
         status: "SUCCESS"
     }
 }
-
 
 export function createMinimalReport() {
     let newReport = { ...minimalReport }
@@ -45,20 +76,66 @@ export function createMinimalReport() {
     return newReport
 }
 
-
-export function createUploadReport() {
+export function createUploadReport(): UploadReport {
     const dexIngestDateTime = randomTime(new Date())
 
-    let newReport = {
-        ...baseReport,
-        stage_info: createStageInfo(dexIngestDateTime)
+    let newReport: UploadReport = {
+        report_schema_version: "1.0.0",
+        upload_id: faker.string.uuid(),
+        user_id: faker.internet.username(),
+        data_stream_id: `${faker.word.noun()}-${faker.word.verb()}`,
+        data_stream_route: `${faker.word.adjective()}-${faker.word.noun()}`,
+        jurisdiction: faker.string.alpha({length: 3, casing: 'upper' }),
+        sender_id: `${faker.word.adjective()}-${faker.word.noun()}`,
+        data_producer_id: `${faker.word.adjective()}-${faker.word.noun()}`,
+        dex_ingest_datetime: getFormattedDate(dexIngestDateTime),
+        message_metadata: createMessageMetadata(),
+        tags: { tag_field1: `${faker.word.noun()}.${faker.string.nanoid()}` },
+        data: { data_field1: `${faker.word.noun()}.${faker.string.nanoid()}` },
+        content_type: "application/json",
+        content: createContentUploadStarted(),
+        stage_info: createStageInfo(dexIngestDateTime),
     }
-    newReport.upload_id = faker.string.uuid()
-    newReport.message_metadata.message_uuid = faker.string.uuid()
-    newReport.dex_ingest_datetime = getFormattedDate(dexIngestDateTime)
-    newReport.stage_info.start_processing_time = getFormattedDate(addSeconds(dexIngestDateTime, 10))
-    newReport.stage_info.end_processing_time = getFormattedDate(addSeconds(dexIngestDateTime, 20))
     return newReport
+}
+
+export function createUploadReportStarted(report?: UploadReport): UploadReport {
+    report = report || createUploadReport()
+
+    
+    const newReport: UploadReport = {
+        ...report,
+        content: createContentUploadStarted()
+    }
+    return newReport
+}
+
+export function createUploadReportStatus(report?: UploadReport): UploadReport {
+    report = report || createUploadReport()
+    const newReport: UploadReport = {
+        ...report,
+        content: createContentUploadStatus()
+    }
+    return newReport
+}
+
+export function createUploadReportCompleted(report?: UploadReport): UploadReport {
+    report = report || createUploadReport()
+    const newReport: UploadReport = {
+        ...report,
+        content: createContentUploadCompleted()
+    }
+    return newReport
+}
+
+export function createMessageMetadata() : MessageMetadata {    
+    const messageMetadata: MessageMetadata = {
+        message_uuid: "2-2-2-2-2",
+        message_hash: 'messagehash',
+        aggregation: Aggregation.SINGLE,
+        message_index: 1
+    }
+    return messageMetadata
 }
 
 export function createStageInfo(date: Date = new Date()) {
@@ -66,7 +143,7 @@ export function createStageInfo(date: Date = new Date()) {
         service: "UPLOAD API",
         action: "upload-completed",
         version: "0.0.49-SNAPSHOT",
-        status: "SUCCESS",
+        status: Status.SUCCESS,
         start_processing_time: getFormattedDate(addSeconds(date, 10)),
         end_processing_time: getFormattedDate(addSeconds(date, 20))
     }
@@ -100,25 +177,36 @@ export function createStageInfoWithError(date: Date = new Date()) {
     return stage_info_error
 }
 
-export function createContentUploadStarted() {
-    const content = {
+export function createContentUploadStarted(): ContentUploadStarted {
+    const content: ContentUploadStarted = {
         content_schema_name: "upload-started",
         content_schema_version: "1.0.0",
-        status: "SUCCESS"
+        status: Status.SUCCESS
     }
 
     return content
 }
 
-export function createContentUploadCompleted() {
-    const content = {
+export function createContentUploadStatus(): ContentUploadStatus {
+    const content:ContentUploadStatus = {
+        content_schema_name: "upload-status",
+        content_schema_version: "1.0.0",
+        tguid: faker.string.uuid(),
+        offset: 0,
+        size: 1024,
+        filename: "playwright-test-file"
+    }
+    return content
+}
+
+export function createContentUploadCompleted():ContentUploadCompleted {
+    const content:ContentUploadCompleted = {
         content_schema_name: "upload-completed",
         content_schema_version: "1.0.0",
-        status: "SUCCESS"
+        status: Status.SUCCESS
     }
     return content
 }
-
 
 function getFormattedDate(date: Date = new Date()): string {
     // Get timezone offset in minutes and convert to hours:minutes format
@@ -150,11 +238,14 @@ const dataGenerator = {
     randomTime,
     getFormattedDate,
     createUploadReport,
-    createStageInfo,
+    createStageInfo,   
     createStageInfoWithWarning,
     createStageInfoWithError,
     createContentUploadStarted,
     createContentUploadCompleted,
+    createUploadReportStarted,
+    createUploadReportStatus,
+    createUploadReportCompleted
 
 }
 export default dataGenerator;

--- a/test/playwright/fixtures/dataGenerator.ts
+++ b/test/playwright/fixtures/dataGenerator.ts
@@ -25,7 +25,6 @@ const baseReport = {
         status: "SUCCESS"
     }
 }
-    
 
 const minimalReport = {
     upload_id: "uuid",
@@ -101,6 +100,26 @@ export function createStageInfoWithError(date: Date = new Date()) {
     return stage_info_error
 }
 
+export function createContentUploadStarted() {
+    const content = {
+        content_schema_name: "upload-started",
+        content_schema_version: "1.0.0",
+        status: "SUCCESS"
+    }
+
+    return content
+}
+
+export function createContentUploadCompleted() {
+    const content = {
+        content_schema_name: "upload-completed",
+        content_schema_version: "1.0.0",
+        status: "SUCCESS"
+    }
+    return content
+}
+
+
 function getFormattedDate(date: Date = new Date()): string {
     // Get timezone offset in minutes and convert to hours:minutes format
     const offset = -date.getTimezoneOffset();
@@ -124,3 +143,18 @@ function addSeconds(date: Date, seconds: number) {
     newDate.setSeconds(date.getSeconds() + seconds)
     return newDate
 }
+
+const dataGenerator = {
+    addSeconds,
+    createMinimalReport,
+    randomTime,
+    getFormattedDate,
+    createUploadReport,
+    createStageInfo,
+    createStageInfoWithWarning,
+    createStageInfoWithError,
+    createContentUploadStarted,
+    createContentUploadCompleted,
+
+}
+export default dataGenerator;

--- a/test/playwright/fixtures/dataGenerator.ts
+++ b/test/playwright/fixtures/dataGenerator.ts
@@ -130,7 +130,7 @@ export function createUploadReportCompleted(report?: UploadReport): UploadReport
 
 export function createMessageMetadata() : MessageMetadata {    
     const messageMetadata: MessageMetadata = {
-        message_uuid: "2-2-2-2-2",
+        message_uuid: faker.string.uuid(),
         message_hash: 'messagehash',
         aggregation: Aggregation.SINGLE,
         message_index: 1
@@ -241,6 +241,7 @@ const dataGenerator = {
     createStageInfo,   
     createStageInfoWithWarning,
     createStageInfoWithError,
+    createMessageMetadata,
     createContentUploadStarted,
     createContentUploadCompleted,
     createUploadReportStarted,


### PR DESCRIPTION
Updating getReport tests

- test that gets report with timestamps in ascending order
- test that gets report with timestamps in descending order
- test for validating upload-started, upload-completed, upload-status sections
- test for upsert mutation replace to ensure new fields are replaced when using the same upload id