### PR TITLE
listReportSchemas graphql-playwright tests

### DIFF
--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-base-0-0-1-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-base-0-0-1-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Base Report","filename":"base.0.0.1.schema.json","schemaName":"base","schemaVersion":"0.0.1"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-base-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-base-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Base Report","filename":"base.1.0.0.schema.json","schemaName":"base","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-blob-file-copy-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-blob-file-copy-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Blob File Copy Report","filename":"blob-file-copy.1.0.0.schema.json","schemaName":"blob-file-copy","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-metadata-transform-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-metadata-transform-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Metadata Transform Report","filename":"metadata-transform.1.0.0.schema.json","schemaName":"metadata-transform","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-metadata-verify-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-metadata-verify-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Metadata Verify Report","filename":"metadata-verify.1.0.0.schema.json","schemaName":"metadata-verify","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-completed-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-completed-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Upload Completed Report","filename":"upload-completed.1.0.0.schema.json","schemaName":"upload-completed","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-started-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-started-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Upload Started Report","filename":"upload-started.1.0.0.schema.json","schemaName":"upload-started","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-status-1-0-0-in-local-schema.json
+++ b/test/playwright/tests/__snapshot__/listReportSchemas.spec.ts/listReportSchemas-query-matches-snapshot-for-schema-upload-status-1-0-0-in-local-schema.json
@@ -1,0 +1,1 @@
+{"description":"Upload Status Report","filename":"upload-status.1.0.0.schema.json","schemaName":"upload-status","schemaVersion":"1.0.0"}

--- a/test/playwright/tests/listReportSchemas.spec.ts
+++ b/test/playwright/tests/listReportSchemas.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@fixtures/gql';
+
+test.describe("listReportSchemas query", async () => {
+  const expectedSchemas = [
+    { schemaName: 'base', version: '1.0.0' },
+    { schemaName: 'base', version: '0.0.1' },
+    { schemaName: 'metadata-verify', version: '1.0.0' },
+    { schemaName: 'blob-file-copy', version: '1.0.0' },
+    { schemaName: 'upload-started', version: '1.0.0' },
+    { schemaName: 'upload-completed', version: '1.0.0' },
+    { schemaName: 'metadata-transform', version: '1.0.0' },
+    { schemaName: 'upload-status', version: '1.0.0' }
+  ];
+    
+  expectedSchemas.forEach(expectedSchema => {
+    test(`matches snapshot for schema ${expectedSchema.schemaName}/${expectedSchema.version} in ${process.env.ENV}`, async ({ gql }, testInfo) => {
+      const response = await gql.listReportSchemas();
+      const schema = response.listReportSchemas.find(
+        schema => schema.schemaName === expectedSchema.schemaName && 
+        schema.schemaVersion === expectedSchema.version
+      );
+      expect(JSON.stringify(schema)).toMatchSnapshot(`schema.json`);
+    });
+  });
+
+  test(`validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+    const response = await gql.listReportSchemas();
+    
+    expect(Array.isArray(response.listReportSchemas)).toBe(true);
+    
+    if (response.listReportSchemas.length > 0) {
+      const schema = response.listReportSchemas[0];
+      
+      expect(schema).toHaveProperty('description');
+      expect(schema).toHaveProperty('filename');
+      expect(schema).toHaveProperty('schemaName');
+      expect(schema).toHaveProperty('schemaVersion');
+      
+      expect(typeof schema.description).toBe('string');
+      expect(typeof schema.filename).toBe('string');
+      expect(typeof schema.schemaName).toBe('string');
+      expect(typeof schema.schemaVersion).toBe('string');
+    }
+  });
+});

--- a/test/playwright/tests/listReportSchemas.spec.ts
+++ b/test/playwright/tests/listReportSchemas.spec.ts
@@ -15,6 +15,9 @@ test.describe("listReportSchemas query", async () => {
   expectedSchemas.forEach(expectedSchema => {
     test(`matches snapshot for schema ${expectedSchema.schemaName}/${expectedSchema.version} in ${process.env.ENV}`, async ({ gql }, testInfo) => {
       const response = await gql.listReportSchemas();
+      
+      expect(response.listReportSchemas.length).toBeGreaterThan(0);
+
       const schema = response.listReportSchemas.find(
         schema => schema.schemaName === expectedSchema.schemaName && 
         schema.schemaVersion === expectedSchema.version
@@ -27,19 +30,18 @@ test.describe("listReportSchemas query", async () => {
     const response = await gql.listReportSchemas();
     
     expect(Array.isArray(response.listReportSchemas)).toBe(true);
+
+    expect(response.listReportSchemas.length).toBeGreaterThan(0);
     
-    if (response.listReportSchemas.length > 0) {
-      const schema = response.listReportSchemas[0];
-      
-      expect(schema).toHaveProperty('description');
-      expect(schema).toHaveProperty('filename');
-      expect(schema).toHaveProperty('schemaName');
-      expect(schema).toHaveProperty('schemaVersion');
-      
-      expect(typeof schema.description).toBe('string');
-      expect(typeof schema.filename).toBe('string');
-      expect(typeof schema.schemaName).toBe('string');
-      expect(typeof schema.schemaVersion).toBe('string');
-    }
+    const schema = response.listReportSchemas[0];
+    expect(schema).toHaveProperty('description');
+    expect(schema).toHaveProperty('filename');
+    expect(schema).toHaveProperty('schemaName');
+    expect(schema).toHaveProperty('schemaVersion');
+    
+    expect(typeof schema.description).toBe('string');
+    expect(typeof schema.filename).toBe('string');
+    expect(typeof schema.schemaName).toBe('string');
+    expect(typeof schema.schemaVersion).toBe('string');
   });
 });


### PR DESCRIPTION
Adding tests for listReportSchemas with snapshot files for individual schema responses

- Adding a test for testing the basic structure of the listReportSchema response
- Adding a test to snapshot the response object for known, default schemas in the system

