### PR TITLE
Adding tests for schemaContentFromFilename to extend schemaContent tests

### DIFF
--- a/test/playwright/tests/schemaContent.spec.ts
+++ b/test/playwright/tests/schemaContent.spec.ts
@@ -16,16 +16,16 @@ test.describe("schemaContent query", async () => {
     });
     
     const expectedSchemas = [
-        { schemaName: 'base', version: '1.0.0' },
-        { schemaName: 'base', version: '0.0.1' },
-        { schemaName: 'metadata-verify', version: '1.0.0' },
-        { schemaName: 'blob-file-copy', version: '1.0.0' },
-        { schemaName: 'upload-started', version: '1.0.0' },
-        { schemaName: 'upload-completed', version: '1.0.0' },
-        { schemaName: 'metadata-transform', version: '1.0.0' },
-        { schemaName: 'upload-status', version: '1.0.0' },
-        { schemaName: 'complex', version: '1.0.0' },
-        { schemaName: 'complex', version: '2.0.0' }
+        { schemaName: 'base', version: '1.0.0', schemaFilename: 'base.1.0.0.schema.json' },
+        { schemaName: 'base', version: '0.0.1', schemaFilename: 'base.0.0.1.schema.json' },
+        { schemaName: 'metadata-verify', version: '1.0.0', schemaFilename: 'metadata-verify.1.0.0.schema.json' },
+        { schemaName: 'blob-file-copy', version: '1.0.0', schemaFilename: 'blob-file-copy.1.0.0.schema.json' },
+        { schemaName: 'upload-started', version: '1.0.0', schemaFilename: 'upload-started.1.0.0.schema.json' },
+        { schemaName: 'upload-completed', version: '1.0.0', schemaFilename: 'upload-completed.1.0.0.schema.json' },
+        { schemaName: 'metadata-transform', version: '1.0.0', schemaFilename: 'metadata-transform.1.0.0.schema.json' },
+        { schemaName: 'upload-status', version: '1.0.0', schemaFilename: 'upload-status.1.0.0.schema.json' },
+        { schemaName: 'complex', version: '1.0.0', schemaFilename: 'complex.1.0.0.schema.json' },
+        { schemaName: 'complex', version: '2.0.0', schemaFilename: 'complex.2.0.0.schema.json' }
     ];
 
     expectedSchemas.forEach(expectedSchema => {
@@ -34,13 +34,20 @@ test.describe("schemaContent query", async () => {
                 schemaName: expectedSchema.schemaName,
                 schemaVersion: expectedSchema.version
             });
-            
+
+            const schemaContentFilenameResponse = await gql.schemaContentFromFilename({
+                schemaFilename: expectedSchema.schemaFilename
+            });
+
             expect(response.schemaContent).toBeDefined();
+            expect(schemaContentFilenameResponse.schemaContentFromFilename).toBeDefined();
+
             expect(JSON.stringify(response.schemaContent)).toMatchSnapshot(`schema-content.json`);
+            expect(JSON.stringify(schemaContentFilenameResponse.schemaContentFromFilename)).toMatchSnapshot(`schema-content.json`);
         });
     });
 
-    test(`validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+    test(`by schema name validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
         const response = await gql.schemaContent({
             schemaName: 'base',
             schemaVersion: '1.0.0'
@@ -48,6 +55,15 @@ test.describe("schemaContent query", async () => {
         
         expect(response).toHaveProperty('schemaContent');
         expect(typeof response.schemaContent).toBe('object');
+    });
+
+    test(`by schema file name validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+        const response = await gql.schemaContentFromFilename({
+            schemaFilename: 'base.1.0.0.schema.json'
+        });
+        
+        expect(response).toHaveProperty('schemaContentFromFilename');
+        expect(typeof response.schemaContentFromFilename).toBe('object');
     });
 
     test('handles invalid schema name gracefully', async ({ gql }) => {
@@ -66,5 +82,21 @@ test.describe("schemaContent query", async () => {
         });
 
         expect(response.schemaContent).toBeNull();
+    });
+
+    test('handles invalid schema file name gracefully', async ({ gql }) => {
+        const response = await gql.schemaContentFromFilename({
+            schemaFilename: 'non-existent-schema.1.0.0.schema.json'
+        });
+
+        expect(response.schemaContentFromFilename).toBeNull();
+    });
+
+    test('handles invalid schema file name version gracefully', async ({ gql }) => {
+        const response = await gql.schemaContentFromFilename({
+            schemaFilename: 'base.999.schema.json'
+        });
+
+        expect(response.schemaContentFromFilename).toBeNull();
     });
 });


### PR DESCRIPTION
1. Added new test cases specifically for `schemaContentFromFilename`:
   - Added snapshot testing for schema content when queried by filename
   - Added a test to validate the response structure when querying by filename
   - Added error handling tests for:
     - Invalid schema filenames
     - Invalid schema filename versions

The changes parallel the existing `schemaContent` tests but add the filename-based query functionality, ensuring consistent behavior between both query methods.