### PR TITLE
Spike: handle interval duration format cron strings

### DIFF
--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -107,20 +107,6 @@ class WorkflowEngine(
         activitiesImpl: T2,
         workflowImplInterface: Class<T3>
     ): T3 {
-        val factory = WorkerFactory.newInstance(client)
-        val worker = factory.newWorker(taskQueue)
-        worker?.let {
-            it.registerWorkflowImplementationTypes(workflowImpl)
-            it.registerActivitiesImplementations(activitiesImpl)
-            logger.info("Workflow and Activity registered for task queue: $taskQueue")
-        } ?: error("Failed to create a worker for task queue: $taskQueue")
-
-        logger.info("Workflow and Activity successfully registered")
-
-        // Start the factory after registering the worker
-        factory.start()
-        logger.info("Worker factory started")
-
         val workflowOptions = WorkflowOptions.newBuilder()
             .setTaskQueue(taskQueue)
             .setMemo(
@@ -137,6 +123,21 @@ class WorkflowEngine(
             workflowOptions
         )
         logger.info("Workflow successfully started")
+
+        val factory = WorkerFactory.newInstance(client)
+        val worker = factory.newWorker(taskQueue)
+        worker?.let {
+            it.registerWorkflowImplementationTypes(workflowImpl)
+            it.registerActivitiesImplementations(activitiesImpl)
+            logger.info("Workflow and Activity registered for task queue: $taskQueue")
+        } ?: error("Failed to create a worker for task queue: $taskQueue")
+
+        logger.info("Workflow and Activity successfully registered")
+
+        // Start the factory after registering the worker
+        factory.start()
+        logger.info("Worker factory started")
+
         return workflow
     }
 

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -107,8 +107,6 @@ class WorkflowEngine(
         activitiesImpl: T2,
         workflowImplInterface: Class<T3>
     ): T3 {
-        CronUtils.checkValid(cronSchedule)
-
         val factory = WorkerFactory.newInstance(client)
         val worker = factory.newWorker(taskQueue)
         worker?.let {

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/utils/CronUtils.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/utils/CronUtils.kt
@@ -12,23 +12,6 @@ import kotlin.jvm.optionals.getOrNull
 
 
 object CronUtils {
-
-    /**
-     * Validates the provided cron expression and throws an IllegalArgumentException if it is invalid.  Note, the
-     * expected CRON type syntax is UNIX.
-     *
-     * @param cronExpression String?
-     * @throws IllegalArgumentException
-     */
-    @Throws(IllegalArgumentException::class)
-    fun checkValid(cronExpression: String?) {
-        if (cronExpression.isNullOrEmpty())
-            throw IllegalArgumentException("Cron expression may not be null or empty")
-
-        val parser = CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX))
-        parser.parse(cronExpression).validate() // throws IllegalArgumentException if invalid
-    }
-
     /**
      * Returns a human-readable version of the provided cron schedule (UNIX format).
      *
@@ -41,7 +24,11 @@ object CronUtils {
         // Parse cronExpression expression and get description
         val parser = CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.UNIX))
         val descriptor = CronDescriptor.instance(Locale.US)
-        return descriptor.describe(parser.parse(cronExpression))
+        return try {
+            descriptor.describe(parser.parse(cronExpression))
+        } catch (e: IllegalArgumentException) {
+            cronExpression
+        }
     }
 
     /**


### PR DESCRIPTION
The goal of this patch is to support the `@<label> <duration>` cron string as described in the [robfig/cron](https://pkg.go.dev/github.com/robfig/cron/v3#section-readme) package (which is the cron package that Temporal uses).  This will enable clients of PS API to set cron schedules such as `@every 1h` or `@every 1d`, while still accepting the traditional unix crontab strings.  These options are not only more user friendly, but enable e2e test automation scripts to set workflow schedules to trigger notifications faster, like every second.  With the traditional crontab strings, the fastest you can do is once a minute.  This will be too slow for e2e tests.

As far as validation goes, Temporal already validates this string when a workflow is attempted to be started.  So the client will still get an error if they try to use a bogus cron string.

For the `describe` helper function, it appears that the `@every` cron format is not supported by the cron helper library.  To account for this, this patch simply returns the string that was passed in.