### PR TITLE
PHDO-715 - Errors returned to graphql fixes

### DIFF
--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/mutations/DataStreamTopErrorsNotificationSubscriptionMutationService.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/mutations/DataStreamTopErrorsNotificationSubscriptionMutationService.kt
@@ -3,7 +3,6 @@ package gov.cdc.ocio.processingstatusapi.mutations
 import com.expediagroup.graphql.generator.annotations.GraphQLDescription
 import com.expediagroup.graphql.server.operations.Mutation
 import gov.cdc.ocio.processingstatusapi.ServiceConnection
-import gov.cdc.ocio.processingstatusapi.exceptions.ResponseException
 import gov.cdc.ocio.processingstatusapi.mutations.response.SubscriptionResponse
 import gov.cdc.ocio.types.model.WorkflowSubscription
 import gov.cdc.ocio.types.model.WorkflowSubscriptionResult
@@ -11,6 +10,8 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
+import java.net.ConnectException
+
 
 /**
  * DataStream UnSubscription data class used for unsubscribing from the db for digest counts and the top errors and
@@ -34,11 +35,8 @@ class DataStreamTopErrorsNotificationSubscriptionMutationService(
     /**
      * The mutation function which invokes the data stream top errors and digest counts microservice route to subscribe.
      *
-     * @param dataStreamId String
-     * @param dataStreamRoute String
-     * @param jurisdiction String
-     * @param cronSchedule String
-     * @param emailAddresses List<String>
+     * @param subscription WorkflowSubscription
+     * @return WorkflowSubscriptionResult
      */
     @GraphQLDescription("Subscribe data stream top errors lets you subscribe to get notifications for top data stream errors and its frequency during an upload")
     @Suppress("unused")
@@ -48,20 +46,16 @@ class DataStreamTopErrorsNotificationSubscriptionMutationService(
         val url = workflowServiceConnection.buildUrl("subscribe/dataStreamTopErrorsNotification")
 
         return runBlocking {
-            val result = runCatching {
-                val response = workflowServiceConnection.client.post(url) {
+            val response = runCatching {
+                workflowServiceConnection.client.post(url) {
                     contentType(ContentType.Application.Json)
                     setBody(subscription)
                 }
-                return@runCatching SubscriptionResponse.ProcessNotificationResponse(response)
-            }
-            result.onFailure {
-                when (it) {
-                    is ResponseException -> throw it
-                    else -> throw Exception(workflowServiceConnection.serviceUnavailable)
-                }
-            }
-            return@runBlocking result.getOrThrow()
+            }.onFailure {
+                if (it is ConnectException)
+                    throw ConnectException(workflowServiceConnection.serviceUnavailable)
+            }.getOrThrow()
+            return@runBlocking SubscriptionResponse.ProcessNotificationResponse(response)
         }
     }
 
@@ -79,20 +73,16 @@ class DataStreamTopErrorsNotificationSubscriptionMutationService(
         val url = workflowServiceConnection.buildUrl("/unsubscribe/dataStreamTopErrorsNotification")
 
         return runBlocking {
-            try {
-                val response = workflowServiceConnection.client.post(url) {
+            val response = runCatching {
+                workflowServiceConnection.client.post(url) {
                     contentType(ContentType.Application.Json)
-                    setBody(
-                        DataStreamTopErrorsNotificationUnSubscription(subscriptionId)
-                    )
+                    setBody(DataStreamTopErrorsNotificationUnSubscription(subscriptionId))
                 }
-                return@runBlocking SubscriptionResponse.ProcessNotificationResponse(response)
-            } catch (e: Exception) {
-                if (e.message!!.contains("Status:")) {
-                    SubscriptionResponse.ProcessErrorCodes(url, e, null)
-                }
-                throw Exception(workflowServiceConnection.serviceUnavailable)
-            }
+            }.onFailure {
+                if (it is ConnectException)
+                    throw ConnectException(workflowServiceConnection.serviceUnavailable)
+            }.getOrThrow()
+            return@runBlocking SubscriptionResponse.ProcessNotificationResponse(response)
         }
     }
 

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/mutations/response/Response.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/mutations/response/Response.kt
@@ -1,11 +1,13 @@
 package gov.cdc.ocio.processingstatusapi.mutations.response
 
+import gov.cdc.ocio.processingstatusapi.exceptions.BadRequestException
+import gov.cdc.ocio.processingstatusapi.exceptions.ForbiddenException
 import gov.cdc.ocio.processingstatusapi.exceptions.ResponseException
-import gov.cdc.ocio.processingstatusapi.mutations.models.NotificationSubscriptionResult
-import gov.cdc.ocio.types.model.WorkflowSubscriptionResult
 import io.ktor.client.call.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.server.plugins.*
+import jdk.jshell.spi.ExecutionControl.InternalException
 import kotlinx.serialization.Serializable
 
 
@@ -14,40 +16,29 @@ data class ResponseError(
     var error: String? = null
 )
 
-object SubscriptionResponse{
-
+object SubscriptionResponse {
 
     /**
-     * Function to process the http response coming from notifications service
+     * Function to process the http response coming from either of the notifications services.
+     *
      * @param response HttpResponse
      */
     @JvmStatic
-    suspend fun ProcessNotificationResponse(response: HttpResponse): WorkflowSubscriptionResult {
+    suspend inline fun<reified T> ProcessNotificationResponse(response: HttpResponse): T {
         if (response.status == HttpStatusCode.OK) {
             return response.body()
         } else {
             // Attempt to get the cause from the response
             val responseError = response.body<ResponseError>()
-            throw ResponseException("Error: ${responseError.error}")
-        }
-    }
-
-    /**
-     * Function to process the http response codes and throw exception accordingly
-     * @param url String
-     * @param e Exception
-     * @param subscriptionId String?
-     */
-    @Throws(Exception::class)
-    fun ProcessErrorCodes(url: String, e: Exception, subscriptionId: String?) {
-        val error = e.message!!.substringAfter("Status:").substringBefore(" ").trim()
-        when (error) {
-            "500" -> throw Exception("Subscription with subscriptionId = $subscriptionId does not exist in the cache")
-            "400" -> throw Exception("Bad Request: Please check the request and retry")
-            "401" -> throw Exception("Unauthorized access to notifications service")
-            "403" -> throw Exception("Access to notifications service is forbidden")
-            "404" -> throw Exception("$url not found")
-            else -> throw Exception(e.message)
+            val error = (responseError.error ?: "Unknown")
+            throw when(response.status) {
+                HttpStatusCode.BadRequest -> BadRequestException(error)
+                HttpStatusCode.Forbidden -> ForbiddenException(error)
+                HttpStatusCode.Unauthorized -> Exception("Unauthorized: $error")
+                HttpStatusCode.NotFound -> NotFoundException(error)
+                HttpStatusCode.InternalServerError -> InternalException(error)
+                else -> ResponseException(error)
+            }
         }
     }
 }

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/CustomGraphQLExceptionHandler.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/CustomGraphQLExceptionHandler.kt
@@ -1,9 +1,5 @@
 package gov.cdc.ocio.processingstatusapi.plugins
 
-import gov.cdc.ocio.processingstatusapi.exceptions.ForbiddenException
-import gov.cdc.ocio.processingstatusapi.exceptions.InsufficientScopesException
-import gov.cdc.ocio.processingstatusapi.exceptions.InvalidTokenException
-import gov.cdc.ocio.processingstatusapi.exceptions.PublicKeyNotFoundException
 import graphql.GraphqlErrorBuilder
 import graphql.execution.DataFetcherExceptionHandler
 import graphql.execution.DataFetcherExceptionHandlerParameters
@@ -29,21 +25,12 @@ class CustomGraphQLExceptionHandler : DataFetcherExceptionHandler {
         val exception = params.exception
         logger.error("GraphQL Error: ${exception.message}", exception)
 
-        val classification = when (exception) {
-            is UnsupportedOperationException -> "UnsupportedOperationException"
-            is ForbiddenException -> "ForbiddenException"
-            is InvalidTokenException -> "InvalidTokenException"
-            is InsufficientScopesException -> "InsufficientScopesException"
-            is PublicKeyNotFoundException -> "PublicKeyNotFoundException"
-            else -> "InternalServerError"
-        }
-
         return CompletableFuture.supplyAsync {
             DataFetcherExceptionHandlerResult.newResult()
                 .error(
                     GraphqlErrorBuilder.newError()
                         .message(exception.message ?: "An error occurred")
-                        .extensions(mapOf("classification" to classification))
+                        .extensions(mapOf("classification" to exception::class.simpleName))
                         .path(params.path)
                         .build()
                 )

--- a/pstatus-notifications-rules-engine-ktor/build.gradle
+++ b/pstatus-notifications-rules-engine-ktor/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "io.ktor:ktor-server-netty:2.3.2"
     implementation("io.ktor:ktor-client-cio:$ktor_version")
     implementation "io.ktor:ktor-server-content-negotiation:2.3.2"
+    implementation "io.ktor:ktor-server-status-pages:2.3.2"
     implementation "io.ktor:ktor-serialization-jackson:$ktor_version"
     implementation "io.ktor:ktor-serialization-kotlinx-json:2.3.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2"

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
@@ -8,15 +8,19 @@ import gov.cdc.ocio.notificationdispatchers.NotificationDispatcherKoinCreator
 import gov.cdc.ocio.processingstatusnotifications.processors.*
 import gov.cdc.ocio.processingstatusnotifications.subscription.CachedSubscriptionLoader
 import gov.cdc.ocio.processingstatusnotifications.subscription.DatabaseSubscriptionLoader
+import io.ktor.http.*
 import io.ktor.serialization.jackson.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.plugins.statuspages.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import org.koin.core.KoinApplication
 import org.koin.ktor.plugin.Koin
 import org.koin.dsl.module
+
 
 /**
  * Load the environment configuration values
@@ -57,5 +61,23 @@ fun Application.module() {
 
     install(ContentNegotiation) {
         jackson()
+    }
+
+    install(StatusPages) {
+        // Map exceptions to HTTP status codes that will be returned
+        val exceptionToHttpStatusCode = mapOf<Class<out Throwable>, HttpStatusCode>(
+            IllegalArgumentException::class.java to HttpStatusCode.BadRequest,
+            IllegalStateException::class.java to HttpStatusCode.InternalServerError,
+        )
+
+        // Intercept all exceptions that occur during routing and return them as bad request errors with the error
+        // message.
+        exception<Exception> { call, cause ->
+            // Check to see if there is an internal cause and provide that if so as those are typically more helpful
+            // than the outer cause.
+            val errorMessage = cause.cause?.message ?: cause.message
+            val httpStatusCode = exceptionToHttpStatusCode[cause.javaClass] ?: HttpStatusCode.InternalServerError
+            call.respond(httpStatusCode, mapOf("error" to errorMessage))
+        }
     }
 }

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/model/SubscriptionResult.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/model/SubscriptionResult.kt
@@ -5,7 +5,5 @@ package gov.cdc.ocio.processingstatusnotifications.model
  * The resultant class for subscription of email/webhooks
  */
 data class SubscriptionResult(
-    var subscriptionId: String? = null,
-    var status: Boolean? = false,
-    var message: String? = null
+    var subscriptionId: String? = null
 )

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/notifications/UnsubscribeNotifications.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/notifications/UnsubscribeNotifications.kt
@@ -2,6 +2,7 @@ package gov.cdc.ocio.processingstatusnotifications.notifications
 
 import gov.cdc.ocio.processingstatusnotifications.model.SubscriptionResult
 import gov.cdc.ocio.processingstatusnotifications.subscription.SubscriptionManager
+import jdk.jshell.spi.ExecutionControl.InternalException
 import mu.KotlinLogging
 
 
@@ -25,17 +26,12 @@ class UnsubscribeNotifications {
     fun run(subscriptionId: String): SubscriptionResult {
         logger.debug { "Received request to unsubscribe from subscriptionId $subscriptionId" }
 
-        val result = SubscriptionResult().apply {
-            this.subscriptionId = subscriptionId
-        }
-        if (subscriptionId.isNotBlank() && unsubscribeNotifications(subscriptionId)) {
-            result.status = true
-            result.message = "Successfully unsubscribed"
-        } else {
-            result.status = false
-            result.message = "Failed to unsubscribe"
-        }
-        return result
+        require(subscriptionId.isNotBlank()) { "Required field subscriptionId can not be blank" }
+
+        if (!unsubscribeNotifications(subscriptionId))
+            error("Failed to unsubscribe, check the subscriptionId is valid")
+
+        return SubscriptionResult(subscriptionId)
     }
 
     /**

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/notifications/UnsubscribeNotifications.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/notifications/UnsubscribeNotifications.kt
@@ -2,7 +2,6 @@ package gov.cdc.ocio.processingstatusnotifications.notifications
 
 import gov.cdc.ocio.processingstatusnotifications.model.SubscriptionResult
 import gov.cdc.ocio.processingstatusnotifications.subscription.SubscriptionManager
-import jdk.jshell.spi.ExecutionControl.InternalException
 import mu.KotlinLogging
 
 

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/DataStreamTopErrorsNotificationSubscriptionService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/DataStreamTopErrorsNotificationSubscriptionService.kt
@@ -61,10 +61,9 @@ class DataStreamTopErrorsNotificationSubscriptionService : KoinComponent {
             subscription
         )
 
-        val workflowId = execution.workflowId
         return WorkflowSubscriptionResult(
             subscriptionId = execution.workflowId,
-            message = "Successfully subscribed for $workflowId",
+            message = "Successfully subscribed",
             emailAddresses = subscription.emailAddresses,
             webhookUrl = subscription.webhookUrl
         )

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/DeadLineCheckSubscriptionService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/DeadLineCheckSubscriptionService.kt
@@ -59,10 +59,9 @@ class DeadLineCheckSubscriptionService: KoinComponent {
             subscription
         )
 
-        val workflowId = execution.workflowId
         return WorkflowSubscriptionResult(
-            subscriptionId = workflowId,
-            message = "Successfully subscribed for $workflowId",
+            subscriptionId = execution.workflowId,
+            message = "Successfully subscribed",
             emailAddresses = subscription.emailAddresses,
             webhookUrl = subscription.webhookUrl
         )

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/UploadDigestCountsNotificationUnSubscriptionService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/UploadDigestCountsNotificationUnSubscriptionService.kt
@@ -29,7 +29,7 @@ class UploadDigestCountsNotificationUnSubscriptionService : KoinComponent {
             workflowEngine.cancelWorkflow(subscriptionId)
             return WorkflowSubscriptionResult(
                 subscriptionId = subscriptionId,
-                message = "Successfully unsubscribed from $subscriptionId",
+                message = "Successfully unsubscribed",
                 emailAddresses = listOf(),
                 webhookUrl = ""
             )


### PR DESCRIPTION
### Summary of changes
- Updated both notification services to throw exceptions when errors occur during subscribe/unsubscribe.
- Exceptions in the notification services are intercepted by the routing "status pages" and the routing calls return an appropriate error message for the exception.
- GraphQL updated to consolidate the error messages for both notifications services.
- Updated the subscribe response for rules engine to only contain the subscription id - message and status are redundant for successful messages and ignored for errors now anyway.