### PR TITLE
Playwright-Graphql Email/Webhook Mock Services Proof of Concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,41 @@ The PS API Notifications services can be deployed along with the core services u
   ```
 - Step 3: Verify that all services are running in Docker Desktop or by running `docker ps`.
 
- 
+#### Setup (Local Mail & Webhook Mocking)
+For local development and testing, you can use a mock email server setup. This allows you to test the notifications functionality without needing to configure a real SMTP server.  A default mock-email.env file has been provided to feed in some default environment variables to be used for local tests.
+
+1. Start the notifications services with the mock email configuration:
+   ```shell
+   docker compose -f docker-compose.notifications.yml --env-file mock-email.env up -d
+   ```
+
+2. Start the test mocks service which provides mock services for email and webhooks:
+   ```shell
+   docker compose -f docker-compose.test-mocks.yml up -d
+   ```
+   This will start additional containers that provide mock implementations for services like smtp email (Mailhog) and webhook listeners (webhook.site) making it easier to test the system in isolation.
+
+##### Email Settings
+When using the mock email setup with Mailhog, the following settings are available:
+
+- Web UI: http://localhost:8025 - View sent emails through the Mailhog web interface
+- SMTP Port: `1025` - The port Mailhog listens on for SMTP connections
+- API Port: `8025` - The port for Mailhog's HTTP API
+
+These settings are configured in `mock-email.env`.
+
+
+##### Webhook Settings
+When using the mock webhook setup with webhook.site, the following settings are available:
+
+- Web UI: http://localhost:8000 - View received webhook calls through the webhook.site interface
+- API Port: `8000` - The port webhook.site listens on for incoming webhook requests
+
+
+
+
+Additional details for automated testing can be found in the [playwright tests folder](./test/playwright/README.md).
+
 ### Next Steps
 Please continue to explore in GraphQL for all the types of queries and mutations that can be done.  GraphQL provides a
 complete list in the documentation that is grabbed via "introspection" from the PS API GraphQL service.

--- a/README.md
+++ b/README.md
@@ -250,9 +250,6 @@ When using the mock webhook setup with webhook.site, the following settings are 
 - Web UI: http://localhost:8000 - View received webhook calls through the webhook.site interface
 - API Port: `8000` - The port webhook.site listens on for incoming webhook requests
 
-
-
-
 Additional details for automated testing can be found in the [playwright tests folder](./test/playwright/README.md).
 
 ### Next Steps

--- a/docker-compose.test-mocks.yml
+++ b/docker-compose.test-mocks.yml
@@ -1,0 +1,15 @@
+name: pstatus-test-mocks
+
+services:
+  mailhog:
+    image: mailhog/mailhog:latest
+    container_name: mailhog
+    ports:
+      - "1025:1025"  # SMTP port
+      - "8025:8025"  # Web UI
+    networks:
+      - temporal-network
+
+networks:
+  temporal-network:
+    external: true 

--- a/docker-compose.test-mocks.yml
+++ b/docker-compose.test-mocks.yml
@@ -9,7 +9,55 @@ services:
       - "8025:8025"  # Web UI
     networks:
       - temporal-network
+      - mock-network
+  webhook:
+    container_name: webhook-site
+    image: "webhooksite/webhook.site"
+    command: php artisan queue:work --daemon --tries=3 --timeout=10
+    ports:
+      - "8084:80"
+    environment:
+      - APP_ENV=dev
+      - APP_DEBUG=true
+      - APP_URL=http://webhook:8084
+      - APP_LOG=errorlog
+      - DB_CONNECTION=sqlite
+      - REDIS_HOST=redis
+      - BROADCAST_DRIVER=redis
+      - CACHE_DRIVER=redis
+      - QUEUE_DRIVER=redis
+      - ECHO_HOST_MODE=path
+    depends_on:
+      - redis
+    networks:
+      - temporal-network
+      - mock-network
+  redis:
+    container_name: "webhook-redis"
+    image: "redis:alpine"
+    networks:
+      - mock-network
+  laravel-echo-server:
+    container_name: "laravel-echo-server"
+    image: "webhooksite/laravel-echo-server"
+    environment:
+      - LARAVEL_ECHO_SERVER_AUTH_HOST=http://webhook
+      - LARAVEL_ECHO_SERVER_HOST=0.0.0.0
+      - LARAVEL_ECHO_SERVER_PORT=6001
+      - ECHO_REDIS_PORT=6379
+      - ECHO_REDIS_HOSTNAME=redis
+      - ECHO_PROTOCOL=http
+      - ECHO_ALLOW_CORS=true
+      - ECHO_ALLOW_ORIGIN=*
+      - ECHO_ALLOW_METHODS=*
+      - ECHO_ALLOW_HEADERS=*
+    networks:
+      - temporal-network
+      - mock-network
 
 networks:
+  mock-network:
+    driver: bridge
+    name: mock-network
   temporal-network:
     external: true 

--- a/mock-email.env
+++ b/mock-email.env
@@ -1,0 +1,5 @@
+# mailhog.env
+SMTP_HOST=mailhog
+SMTP_PORT=1025
+SMTP_AUTH=false
+EMAIL_PROTOCOL=smtp

--- a/test/playwright/tests/subscribeUploadDigestCounts.spec.ts
+++ b/test/playwright/tests/subscribeUploadDigestCounts.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@fixtures/gql';
+import { NotificationType, WorkflowSubscriptionInput } from '@gql';
+
+test.describe('GraphQL subscribeUploadDigestCounts', () => {
+    test('subscribes to uploadDigestCounts via email', async ({ gql, request }) => {
+        test.setTimeout(120000); 
+        
+        const subscriptionEmail = "subscribeUploadDigestCounts@test.com"
+        const expectedEmailAddresses = [ subscriptionEmail ]
+        const subscription: WorkflowSubscriptionInput = {
+            cronSchedule: "* * * * *",
+			dataStreamIds: ["dextesting"],
+			dataStreamRoutes: ["testevent1"],
+			jurisdictions: ["test"],
+			emailAddresses: expectedEmailAddresses,
+			notificationType: NotificationType.Email,
+			sinceDays: 1,
+        }
+
+        const res = await gql.subscribeUploadDigestCounts({ subscription });
+        expect(res.subscribeUploadDigestCounts).toBeDefined();
+        expect(res.subscribeUploadDigestCounts.emailAddresses).toContain(subscriptionEmail);
+        expect(res.subscribeUploadDigestCounts.message).toBe("Successfully subscribed");
+
+        const unsubscribeId = res.subscribeUploadDigestCounts.subscriptionId!.toString();
+
+        await expect.poll(async () => {
+            const mailhogResponse = await request.get('http://localhost:8025/api/v2/search?kind=containing&query=' + subscriptionEmail);
+            const emails = await mailhogResponse.json();
+            return emails.total;
+        }, {
+            message: 'Email should be found',
+            timeout: 60000, // 1 minute timeout
+        }).toBeGreaterThan(0);
+
+        const mailhogResponse = await request.get('http://localhost:8025/api/v2/search?kind=containing&query=' + subscriptionEmail);
+        const emails = await mailhogResponse.json();
+        expect(emails.items[0].Content.Headers.To[0]).toBe(subscriptionEmail);
+        expect(emails.items[0].Content.Headers.Subject[0]).toContain("PHDO UPLOAD DIGEST NOTIFICATION");
+        
+        await gql.unsubscribeUploadDigestCounts({ subscriptionId: unsubscribeId });
+    });
+});


### PR DESCRIPTION
Playwright-Graphql Email/Webhook Mock Services Proof of Concept

1. Added Docker Compose configuration for test mocks:
   - Mailhog service for email testing

2. Added Webhook.site Docker image:
   - Local webhook testing capabilities

3. Added proof of concept test:
   - Email verification for notification subscriptions
   - Integration with Mailhog for email checking
   - Retry mechanism for email verification
   - Increased test timeout to accommodate email delivery
