### PR TITLE
PHDO 750 - Tests for subscribeDataStreamTopErrorsNotification

### DIFF
--- a/test/playwright/README.md
+++ b/test/playwright/README.md
@@ -16,6 +16,8 @@ The primary technologies and tools used in this project are:
   - [gqlg](https://www.npmjs.com/package/gqlg) - Generates queries from fetched GraphQL schemas.
   - [graphql-codegen](https://www.npmjs.com/package/@graphql-codegen/cli) - Generates TypeScript interfaces for queries for use in Playwright.
 - [TypeScript](https://www.typescriptlang.org/) - Typed superset of JavaScript for better maintainability.
+- [MailHog](https://github.com/mailhog/MailHog) - Local smtp mock email server
+- [webhook.site](https://github.com/webhooksite/webhook.site) - Webhook listener for testing
 
 ## Setup and Installation
 
@@ -24,15 +26,44 @@ The primary technologies and tools used in this project are:
    npm install
    ```
 ### Configuring the environment
-Configure where to get the schema from
--  Edit the `package.json` `generate:schema` script to point to the environment where you want to get the schemas from
 
-Configure where to point the tests
-- Edit the `playwright.config.ts` file and update the `baseURL` in the project to define the URL where tests should be run against
+A default `.env` file is provided in `/test/playwright` with the following configuration parameters for use with the default settings when running locally in a docker container (as detailed below)
+
+| Parameter | Description | Default Value |
+|-----------|-------------|---------------|
+| `ENV` | Environment name for test execution | `local` |
+| `BASEURL` | GraphQL endpoint URL | `http://127.0.0.1:8090/graphql` |
+| `EMAILURL` | Email service URL for notifications | `http://127.0.0.1:8025` |
+| `WEBHOOKURL` | Webhook service URL | `http://webhook:80` |
+| `WEBHOOKAPI` | Webhook API endpoint | `http://localhost:8084` |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | SSL/TLS verification setting | `0` |
+| `GRAPHQL_AUTH_TOKEN` | Authentication token for GraphQL requests | `LET_ME_IN_PLS_THANKS` |
+
+To configure the test environment:
+
+**Schema Source Configuration**:
+   - Edit the BASEURL in the `.env` file to point to your test environment
+
+### Setting up local docker configuration
+
+1. Run the base Processing Status API (from project base directory)
+```bash
+docker compose up -d
+```
+
+2. Run the Processing Status Notitfications API (with mock services .env) (from project base directory)
+```bash
+docker compose -f docker-compose.notifications.yml --env-file mock-email.env up -d
+```
+
+3. Run the Mock Services for Tests (from project base directory)
+```bash
+docker compose -f docker-compose.test-mocks.yml up -d
+```
 
 ## Usage
 
-To use this project, follow these steps:
+To setup and run the tests: 
 
 1. **Run the code generation script**:
    This script will generate the required GraphQL schema, operations, and TypeScript types.
@@ -46,15 +77,10 @@ To use this project, follow these steps:
    npm run test
    ```
 
-## Scripts
-
-List key npm scripts and their descriptions:
+## NPM Scripts
 
 | Script                        | Description                                                         |
 |-------------------------------|---------------------------------------------------------------------|
-| `npm run generate:schema`     | Fetch the GraphQL schema from the endpoint and save it locally.     |
-| `npm run generate:operations` | Generate GraphQL queries and mutations from the schema.             |
-| `npm run generate:types`      | Generate TypeScript types for the GraphQL schema.                   |
 | `npm run codegen`             | Run all code generation scripts (schema, operations, and types).    |
 | `npm run test`                | Run all Playwright tests.                                           |
 

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-invalid-chron-schedule-invalid-cron
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-invalid-chron-schedule-invalid-cron
@@ -1,0 +1,1 @@
+[{"message":"INVALID_ARGUMENT: invalid CronSchedule.","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-invalid-notification-type-invalid-notification-type
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-invalid-notification-type-invalid-notification-type
@@ -1,0 +1,1 @@
+[{"message":"Variable 'subscription' has an invalid value: Invalid input for enum 'NotificationType'. No value found for name 'INVALID'","locations":[{"line":1,"column":51}]}]

--- a/test/playwright/tests/subscribeDataStreamTopErrorsNotification.spec.ts
+++ b/test/playwright/tests/subscribeDataStreamTopErrorsNotification.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect } from '@fixtures/gql';
+import { NotificationType } from '@gql';
+import { GraphQLError } from 'graphql';
+import { createSubscriptionInput } from '../fixtures/dataGenerator';
+
+const EMAIL_SERVICE = process.env.EMAILURL || "http://localhost:8025";
+const WEBHOOK_SERVICE = process.env.WEBHOOKURL || "http://webhook:80";
+const WEBHOOK_SERVICE_UI = process.env.WEBHOOKAPI || "http://localhost:8084";
+
+type GraphQLErrorResponse = { errors: GraphQLError[] };
+
+let subscriptions:string[] = []
+
+test.describe('GraphQL subscribeDataStreamTopErrorsNotification', () => {
+    test.setTimeout(90000); 
+
+    test.beforeAll(async ({ request }) => { 
+        const mailhogResponse = await request.delete(`${EMAIL_SERVICE}/api/v1/messages`);
+        expect(mailhogResponse.status()).toBe(200);
+    });
+
+    test.afterEach(async ({ gql }) => { 
+        subscriptions.forEach(async (subscriptionId) => {
+            const response = await gql.unsubscribeNotificationWorkflow({ subscriptionId: subscriptionId });
+            expect(response.unsubscribeNotificationWorkflow.subscriptionId).toBe(subscriptionId);
+        });
+        subscriptions = [];
+    });
+
+    test('subscribing via email with duration cron', async ({ gql, request }) => {
+        const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-cron-duration@test.com`;
+        const subscription = createSubscriptionInput({
+            emailAddresses: [subscriptionEmail],
+            cronSchedule: "@every 10s"
+        });
+
+        const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription });
+        expect(res.subscribeDataStreamTopErrorsNotification).toBeDefined();
+        expect(res.subscribeDataStreamTopErrorsNotification.subscriptionId).toBeDefined();
+        
+        const subscriptionId = res.subscribeDataStreamTopErrorsNotification.subscriptionId!.toString();
+        subscriptions.push(subscriptionId);
+
+        await expect.poll(async () => {
+            const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+            const emails = await mailhogResponse.json();
+            return emails.total;
+        }, {
+            message: 'Email should be found',
+            timeout: 60000,
+        }).toBeGreaterThan(0);
+
+        const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+        const emails = await mailhogResponse.json();
+        expect(emails.items[0].Content.Headers.To[0]).toBe(subscriptionEmail);
+        expect(emails.items[0].Content.Headers.Subject[0]).toContain("DATA STREAM TOP ERRORS NOTIFICATION");
+    });
+
+    test('subscribing via email with classic cron', async ({ gql, request }) => {        
+        const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-cron-classic@test.com`;
+        const subscription = createSubscriptionInput({
+            emailAddresses: [subscriptionEmail],
+            cronSchedule: "* * * * *"
+        });
+
+        const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription });
+        expect(res.subscribeDataStreamTopErrorsNotification).toBeDefined();
+        expect(res.subscribeDataStreamTopErrorsNotification.subscriptionId).toBeDefined();
+
+        const subscriptionId = res.subscribeDataStreamTopErrorsNotification.subscriptionId!.toString();
+        subscriptions.push(subscriptionId);
+
+        await expect.poll(async () => {
+            const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+            const emails = await mailhogResponse.json();
+            return emails.total;
+        }, {
+            message: 'Email should be found',
+            timeout: 60000,
+        }).toBeGreaterThan(0);
+
+        const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+        const emails = await mailhogResponse.json();
+        expect(emails.items[0].Content.Headers.To[0]).toBe(subscriptionEmail);
+        expect(emails.items[0].Content.Headers.Subject[0]).toContain("DATA STREAM TOP ERRORS NOTIFICATION");
+    });
+
+    test('subscribing via webhook with duration cron', async ({ gql, request }) => {
+        const tokenRequest = await request.post(`${WEBHOOK_SERVICE_UI}/token`);
+        const token = await tokenRequest.json();
+        const webhookUrl = `${WEBHOOK_SERVICE}/${token.uuid}`;
+
+        const subscription = createSubscriptionInput({
+            webhookUrl: webhookUrl,
+            cronSchedule: "@every 5s",
+            notificationType: NotificationType.Webhook
+        });
+
+        const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription });
+        expect(res.subscribeDataStreamTopErrorsNotification).toBeDefined();
+        expect(res.subscribeDataStreamTopErrorsNotification.subscriptionId).toBeDefined();
+
+        const subscriptionId = res.subscribeDataStreamTopErrorsNotification.subscriptionId!.toString();
+        subscriptions.push(subscriptionId);
+        
+        await expect.poll(async () => {
+            const webhooksiteResponse = await request.get(`${WEBHOOK_SERVICE_UI}/token/${token.uuid}/requests`);
+            const webhookRequests = await webhooksiteResponse.json();
+            return webhookRequests.total
+        }, {
+            message: "Webhook should be called",
+            intervals: [5000],
+            timeout: 20000,
+        }).toBeGreaterThan(0);
+    });
+
+    test('subscribing via webhook with classic cron', async ({ gql, request }) => {
+        const tokenRequest = await request.post(`${WEBHOOK_SERVICE_UI}/token`);
+        const token = await tokenRequest.json();
+        const webhookUrl = `${WEBHOOK_SERVICE}/${token.uuid}`;
+
+        const subscription = createSubscriptionInput({
+            webhookUrl: webhookUrl,
+            cronSchedule: "* * * * *",
+            notificationType: NotificationType.Webhook
+        });
+
+        const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription });
+        expect(res.subscribeDataStreamTopErrorsNotification).toBeDefined();
+        expect(res.subscribeDataStreamTopErrorsNotification.subscriptionId).toBeDefined();
+
+        const subscriptionId = res.subscribeDataStreamTopErrorsNotification.subscriptionId!.toString();
+        subscriptions.push(subscriptionId);
+        
+        await expect.poll(async () => {
+            const webhooksiteResponse = await request.get(`${WEBHOOK_SERVICE_UI}/token/${token.uuid}/requests`);
+            const webhookRequests = await webhooksiteResponse.json();
+            return webhookRequests.total
+        }, {
+            message: "Webhook should be called",
+            intervals: [5000],
+            timeout: 600000,
+        }).toBeGreaterThan(0);
+    });
+
+    test('subscribing to a specific data stream via email', async ({ gql, request }) => {
+        const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream@test.com`;
+        const subscription = createSubscriptionInput({
+            emailAddresses: [subscriptionEmail],
+            cronSchedule: "@every 10s",
+            dataStreamIds: ["dextesting"],
+            dataStreamRoutes: ["testevent1"],
+            jurisdictions: ["jurisdiction"]
+        });
+
+        const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription });
+        expect(res.subscribeDataStreamTopErrorsNotification).toBeDefined();
+        expect(res.subscribeDataStreamTopErrorsNotification.subscriptionId).toBeDefined();
+
+        const subscriptionId = res.subscribeDataStreamTopErrorsNotification.subscriptionId!.toString();
+        subscriptions.push(subscriptionId);
+        
+        await expect.poll(async () => {
+            const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+            const emails = await mailhogResponse.json();
+            return emails.total;
+        }, {
+            message: 'Email should be found',
+            timeout: 60000,
+        }).toBeGreaterThan(0);
+
+        const mailhogResponse = await request.get(`${EMAIL_SERVICE}/api/v2/search?kind=containing&query=` + subscriptionEmail);
+        const emails = await mailhogResponse.json();
+        expect(emails.items[0].Content.Headers.To[0]).toBe(subscriptionEmail);
+        expect(emails.items[0].Content.Headers.Subject[0]).toContain("DATA STREAM TOP ERRORS NOTIFICATION");
+    });
+
+    test.describe('subscribing errors', () => {
+        test('invalid chron schedule', async ({ gql }) => {
+            const subscription = createSubscriptionInput({
+                emailAddresses: [`subscribeDataStreamTopErrorsNotification-error-cron@test.com`],
+                cronSchedule: "INVALID"
+            });
+
+            const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("invalid-cron");
+        });
+
+        test('invalid notification type', async ({ gql }) => {
+            const subscription = createSubscriptionInput({
+                emailAddresses: [`subscribeDataStreamTopErrorsNotification-error-notification-type@test.com`],
+                notificationType: "INVALID" as unknown as NotificationType
+            });
+
+            const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("invalid-notification-type");
+        });
+
+        test.skip('invalid email format', async ({ gql }) => {
+            const subscription = createSubscriptionInput({
+                emailAddresses: [`subscribeDataStreamTopErrorsNotification-error-invalid-email`],
+                notificationType: NotificationType.Email
+            });
+
+            const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("invalid-email-format");
+        });
+
+        test.skip('invalid webhook format', async ({ gql }) => {
+            const subscription = createSubscriptionInput({
+                webhookUrl: "bad/webhook/url",
+                notificationType: NotificationType.Webhook
+            });
+
+            const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("invalid-email-format");
+        });
+    });
+});


### PR DESCRIPTION
Branch name for this wasn't quite right.  This is for subscribeDataStreamTopErrorsNotification

# Data Stream Top Errors Notification Tests
## Test Coverage

- Email Notification Tests
  - Tests for duration-based cron schedules (@every 10s)
  - Tests for classic cron schedules (* * * * *)
  - Tests for specific data stream subscriptions with:
  - Data stream ID filtering
  - Route filtering
  - Jurisdiction filtering
- Webhook Notification Tests
  - Tests for duration-based cron schedules (@every 5s)
  - Tests for classic cron schedules (* * * * *)
  - Tests for webhook token authentication
  - Tests for webhook request validation

## Test Infrastructure

- Uses Playwright for test execution
- Integrates with Mailhog for email testing
- Integrates with webhook service for testing
- Implements proper test cleanup (subscription removal)
- Includes snapshot testing for error cases

## Error Case Testing

- Invalid cron schedules
- Invalid notification types
- Invalid email formats (skipped)
- Invalid webhook URLs (skipped)