### PR TITLE
PHDO-778 - Fix top errors delayed upload query

### DIFF
--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/ReportService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/ReportService.kt
@@ -79,9 +79,10 @@ class ReportService: KoinComponent {
     ): List<UploadInfo> {
         val oneHourAgo = Instant.now().minus(1, ChronoUnit.HOURS).epochSecond
         val oneWeekAgo = LocalDate.now().minusWeeks(1).atStartOfDay(ZoneId.systemDefault()).toInstant().epochSecond
+        // Time range for delayed uploads are those that are older than an hour ago but not older than a week ago
         val timeRangeSection = """
-            AND ${cPrefix}dexIngestDateTime < ${timeFunc(oneHourAgo)} // older than an hour ago
-            AND ${cPrefix}dexIngestDateTime > ${timeFunc(oneWeekAgo)} // but not older than a week ago
+            AND ${cPrefix}dexIngestDateTime < ${timeFunc(oneHourAgo)}
+            AND ${cPrefix}dexIngestDateTime > ${timeFunc(oneWeekAgo)}
             ${appendTimeRange(daysInterval)}
         """.trimIndent()
         return getPendingUploads(dataStreamId, dataStreamRoute, timeRangeSection)

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/workflow/toperrors/TopErrorsEmailBuilder.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/workflow/toperrors/TopErrorsEmailBuilder.kt
@@ -110,7 +110,7 @@ class TopErrorsEmailBuilder(
                     p {
                         +"[1] A "
                         b { +"delayed upload" }
-                        +" is an upload that was initiated but has not completed in more than one hour."
+                        +" is an upload that was initiated but has not completed in more than one hour. Delayed uploads that are more than a week old will not be shown."
                     }
                     p {
                         +"[2] A "


### PR DESCRIPTION
### Summary of changes
- Fix to the time range filter for delayed uploads. It correctly looked for incomplete uploads older than an hour ago, but failed to cut off uploads older than a week ago. Delayed uploads older than a week ago go in the abandoned uploads bucket.
- Updated the email text description of delayed uploads. Now states that delayed uploads does not include ones older than a week.