### PR TITLE
PHDO-782/couchbase metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,10 @@ The following microservices within the PS API system are capable of emitting met
 - notifications-workflow
 
 This telemetry can be enabled and emitted by setting the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable for each microservice.
-This endpoint should be something that is capable of accepting data in OTLP format over HTTP and GRPC.  For local development
-convenience and to mimic the production environment, the `docker-compose.monitoring.yml` file has been created to orchestrate an
+This endpoint should be something that is capable of accepting data in OTLP format over HTTP and GRPC.  Additionally, you
+can optionally set the `OTEL_SERVICE_NAME` enviornment variable to set a unique name for the service attribute that gets appended
+to the otel data.
+For local development convenience and to mimic the production environment, the `docker-compose.monitoring.yml` file has been created to orchestrate an
 OpenTelemetry Collector service for ingesting the emitted telemetry, as well as a Tempo service for storing traces and a
 Prometheus service for scraping and storing metrics.
 

--- a/libs/commons-database/build.gradle
+++ b/libs/commons-database/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     implementation 'org.owasp.encoder:encoder:1.2.3'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.3.1'
 
+    implementation 'com.couchbase.client:metrics-opentelemetry:0.4.4'
+    implementation 'io.opentelemetry:opentelemetry-api'
+    implementation 'io.opentelemetry:opentelemetry-sdk:1.49.0'
+
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
     testImplementation "org.testng:testng:7.4.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
@@ -56,9 +56,9 @@ class CouchbaseRepository(
     private val logger = KotlinLogging.logger {}
 
     // Connect without customizing the cluster environment
-    private var cluster: Cluster //= Cluster.connect(connectionString, username, password)
+    private var cluster: Cluster
 
-    private val processingStatusBucket: Bucket// = cluster.bucket(bucketName)
+    private val processingStatusBucket: Bucket
 
     private val scope: Scope
 

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
@@ -6,7 +6,6 @@ import gov.cdc.ocio.database.persistence.Collection
 import com.couchbase.client.java.Cluster
 import com.couchbase.client.java.ClusterOptions
 import com.couchbase.client.java.Scope
-import com.couchbase.client.java.manager.collection.CollectionSpec
 import com.couchbase.client.java.manager.collection.CreateCollectionSettings
 import com.couchbase.client.metrics.opentelemetry.OpenTelemetryMeter
 import gov.cdc.ocio.database.health.HealthCheckCouchbaseDb
@@ -15,7 +14,6 @@ import gov.cdc.ocio.types.adapters.NotificationTypeAdapter
 import gov.cdc.ocio.types.health.HealthCheckSystem
 import gov.cdc.ocio.types.model.Notification
 import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.OpenTelemetry
 import mu.KotlinLogging
 import java.time.Duration
 

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/telemetry/Otel.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/telemetry/Otel.kt
@@ -1,0 +1,23 @@
+package gov.cdc.ocio.database.telemetry
+
+import io.opentelemetry.sdk.metrics.Aggregation
+import io.opentelemetry.sdk.metrics.View
+
+object Otel {
+    /**
+     * Returns a more appropriate list of buckets for OpenTelemetry histograms.  Each bucket is in nanoseconds.
+     */
+    fun getDefaultHistogramView(): View {
+        return View.builder().setAggregation(
+            Aggregation.explicitBucketHistogram(
+                listOf(100000.0,
+                    250000.0,
+                    500000.0,
+                    1000000.0,
+                    10000000.0,
+                    100000000.0,
+                    1000000000.0,
+                    10000000000.0)
+            )).build()
+    }
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
@@ -10,6 +10,7 @@ import gov.cdc.ocio.database.dynamo.DynamoRepository
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import io.ktor.server.application.*
 import io.ktor.server.config.*
+import io.opentelemetry.api.OpenTelemetry
 import mu.KotlinLogging
 import org.koin.core.module.Module
 import org.koin.dsl.module

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/DatabaseKoinCreator.kt
@@ -10,7 +10,6 @@ import gov.cdc.ocio.database.dynamo.DynamoRepository
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import io.ktor.server.application.*
 import io.ktor.server.config.*
-import io.opentelemetry.api.OpenTelemetry
 import mu.KotlinLogging
 import org.koin.core.module.Module
 import org.koin.dsl.module

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
@@ -1,5 +1,6 @@
 package gov.cdc.ocio.processingstatusnotifications
 
+import gov.cdc.ocio.database.telemetry.Otel
 import gov.cdc.ocio.database.utils.DatabaseKoinCreator
 import gov.cdc.ocio.messagesystem.models.MessageSystemType
 import gov.cdc.ocio.messagesystem.utils.MessageSystemKoinCreator
@@ -22,6 +23,8 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.ktor.v2_0.KtorServerTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.InstrumentSelector
+import io.opentelemetry.sdk.metrics.InstrumentType
 import io.opentelemetry.semconv.ServiceAttributes
 import org.koin.core.KoinApplication
 import org.koin.ktor.plugin.Koin
@@ -61,14 +64,19 @@ fun Application.module() {
 
     createMessageSystemPlugin(MessageSystemType.getFromAppEnv(environment), MessageProcessor())
 
-    val builder = AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { old, _ ->
+    val builder = AutoConfiguredOpenTelemetrySdk.builder()
+        .setResultAsGlobal()
+        .addResourceCustomizer { old, _ ->
         old.toBuilder()
             .putAll(old.attributes)
             .put(ServiceAttributes.SERVICE_NAME, environment.config.tryGetString("otel.service_name") ?: "pstatus-notifications-rules-engine")
             .build()
     }
+        .addMeterProviderCustomizer { old, _ ->
+            old.registerView(
+                InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(), Otel.getDefaultHistogramView())
+        }
     val otel: OpenTelemetry = builder.build().openTelemetrySdk
-    GlobalOpenTelemetry.set(otel)
     install(KtorServerTelemetry) {
         setOpenTelemetry(otel)
     }

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/Application.kt
@@ -18,6 +18,7 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.ktor.v2_0.KtorServerTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
@@ -60,6 +61,18 @@ fun Application.module() {
 
     createMessageSystemPlugin(MessageSystemType.getFromAppEnv(environment), MessageProcessor())
 
+    val builder = AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { old, _ ->
+        old.toBuilder()
+            .putAll(old.attributes)
+            .put(ServiceAttributes.SERVICE_NAME, environment.config.tryGetString("otel.service_name") ?: "pstatus-notifications-rules-engine")
+            .build()
+    }
+    val otel: OpenTelemetry = builder.build().openTelemetrySdk
+    GlobalOpenTelemetry.set(otel)
+    install(KtorServerTelemetry) {
+        setOpenTelemetry(otel)
+    }
+
     install(Koin) {
         loadKoinModules(environment)
     }
@@ -84,16 +97,5 @@ fun Application.module() {
             val httpStatusCode = exceptionToHttpStatusCode[cause.javaClass] ?: HttpStatusCode.InternalServerError
             call.respond(httpStatusCode, mapOf("error" to errorMessage))
         }
-    }
-
-    install(KtorServerTelemetry) {
-        val builder = AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { old, _ ->
-            old.toBuilder()
-                .putAll(old.attributes)
-                .put(ServiceAttributes.SERVICE_NAME, environment.config.tryGetString("otel.service_name") ?: "pstatus-notifications-rules-engine")
-                .build()
-        }
-        val otel: OpenTelemetry = builder.build().openTelemetrySdk
-        setOpenTelemetry(otel)
     }
 }

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/Application.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/Application.kt
@@ -3,6 +3,7 @@ package gov.cdc.ocio.processingnotifications
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import gov.cdc.ocio.database.telemetry.Otel
 import gov.cdc.ocio.database.utils.DatabaseKoinCreator
 import gov.cdc.ocio.notificationdispatchers.NotificationDispatcherKoinCreator
 import gov.cdc.ocio.processingnotifications.config.TemporalConfig
@@ -22,6 +23,8 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.ktor.v2_0.KtorServerTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.InstrumentSelector
+import io.opentelemetry.sdk.metrics.InstrumentType
 import io.opentelemetry.semconv.ServiceAttributes
 import io.temporal.client.WorkflowNotFoundException
 import io.temporal.client.WorkflowServiceException
@@ -55,14 +58,19 @@ fun main(args: Array<String>) {
 }
 
 fun Application.module() {
-    val builder = AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { old, _ ->
+    val builder = AutoConfiguredOpenTelemetrySdk.builder()
+        .setResultAsGlobal()
+        .addResourceCustomizer { old, _ ->
         old.toBuilder()
             .putAll(old.attributes)
             .put(ServiceAttributes.SERVICE_NAME, environment.config.tryGetString("otel.service_name") ?: "pstatus-notifications-workflow")
             .build()
     }
+        .addMeterProviderCustomizer { old, _ ->
+            old.registerView(
+                InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(), Otel.getDefaultHistogramView())
+        }
     val otel: OpenTelemetry = builder.build().openTelemetrySdk
-    GlobalOpenTelemetry.set(otel)
     install(KtorServerTelemetry) {
         setOpenTelemetry(otel)
     }

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
@@ -1,5 +1,6 @@
 package gov.cdc.ocio.processingstatusapi
 
+import gov.cdc.ocio.database.telemetry.Otel
 import gov.cdc.ocio.database.utils.DatabaseKoinCreator
 import gov.cdc.ocio.messagesystem.models.MessageSystemType
 import gov.cdc.ocio.messagesystem.utils.MessageSystemKoinCreator
@@ -20,6 +21,10 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.ktor.v2_0.KtorServerTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.Aggregation
+import io.opentelemetry.sdk.metrics.InstrumentSelector
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.View
 import io.opentelemetry.semconv.ServiceAttributes
 import org.koin.core.KoinApplication
 import org.koin.ktor.plugin.Koin
@@ -76,14 +81,19 @@ fun Application.module() {
 
     createMessageSystemPlugin(messageSystemType, messageProcessor)
 
-    val builder = AutoConfiguredOpenTelemetrySdk.builder().addResourceCustomizer { old, _ ->
+    val builder = AutoConfiguredOpenTelemetrySdk.builder()
+        .setResultAsGlobal()
+        .addResourceCustomizer { old, _ ->
         old.toBuilder()
             .putAll(old.attributes)
             .put(ServiceAttributes.SERVICE_NAME, environment.config.tryGetString("otel.service_name") ?: "pstatus-report-sink")
             .build()
-    }
+        }
+        .addMeterProviderCustomizer { old, _ ->
+            old.registerView(
+                InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(), Otel.getDefaultHistogramView())
+        }
     val otel: OpenTelemetry = builder.build().openTelemetrySdk
-    GlobalOpenTelemetry.set(otel)
     install(KtorServerTelemetry) {
         setOpenTelemetry(otel)
     }


### PR DESCRIPTION
This is a small patch to expand the otel metrics coverage to Couchbase operations.  Per the docs, Couchbase can be configured to emit otel metrics for all operations like kv, query, upsert, etc.  For this patch, these metrics are surfaced as prometheus histograms with buckets in microseconds.  These histograms can be used to get average latencies for these operations.