### PR TITLE
PHDO-785 - Updates for playwright

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -22,7 +22,7 @@ services:
       COUCHBASE_USERNAME: "admin"
       COUCHBASE_PASSWORD: "password"
       REPORT_SCHEMA_LOADER_SYSTEM: "file_system"
-      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "/reports"
+      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "reports"
       PSTATUS_RULES_ENGINE_NOTIFICATIONS_BASE_URL: "http://notifications-rules-engine:8080"
       PSTATUS_WORKFLOW_NOTIFICATIONS_BASE_URL: "http://notifications-workflow:8080"
       SCHEMA_ADMIN_SECRET_TOKEN: "${SCHEMA_ADMIN_SECRET_TOKEN:-LET_ME_IN_PLS_THANKS}"
@@ -30,7 +30,7 @@ services:
       - couchbase
     restart: "always"
     volumes:
-      - ./reports:/reports # Bind mount the report schemas folder
+      - ./reports:/app/reports # Bind mount the report schemas folder
 
   report-sink:
     image: pstatus-report-sink-ktor:latest
@@ -55,13 +55,13 @@ services:
       RABBITMQ_VIRTUAL_HOST: "/"
       FORWARD_VALIDATED_REPORTS: "${FORWARD_VALIDATED_REPORTS:-false}"
       REPORT_SCHEMA_LOADER_SYSTEM: "file_system"
-      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "/reports"
+      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "reports"
     depends_on:
       - couchbase
       - rabbitmq
     restart: "always"
     volumes:
-      - ./reports:/reports # Bind mount the report schemas folder
+      - ./reports:/app/reports # Bind mount the report schemas folder
 
   couchbase:
     image: couchbase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       COUCHBASE_USERNAME: "admin"
       COUCHBASE_PASSWORD: "password"
       REPORT_SCHEMA_LOADER_SYSTEM: "file_system"
-      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "/reports"
+      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "reports"
       PSTATUS_RULES_ENGINE_NOTIFICATIONS_BASE_URL: "http://notifications-rules-engine:8080"
       PSTATUS_WORKFLOW_NOTIFICATIONS_BASE_URL: "http://notifications-workflow:8080"
       SCHEMA_ADMIN_SECRET_TOKEN: "${SCHEMA_ADMIN_SECRET_TOKEN:-LET_ME_IN_PLS_THANKS}"
@@ -31,7 +31,7 @@ services:
       - couchbase
     restart: "always"
     volumes:
-      - ./reports:/reports # Bind mount the report schemas folder
+      - ./reports:/app/reports # Bind mount the report schemas folder
 
   report-sink:
     image: quay.io/us-cdcgov/phdo/pstatus-report-sink:latest
@@ -56,14 +56,14 @@ services:
       RABBITMQ_VIRTUAL_HOST: "/"
       FORWARD_VALIDATED_REPORTS: "${FORWARD_VALIDATED_REPORTS:-false}"
       REPORT_SCHEMA_LOADER_SYSTEM: "file_system"
-      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "/reports"
+      REPORT_SCHEMA_LOCAL_FILE_SYSTEM_PATH: "reports"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otelcol:4317
     depends_on:
       - couchbase
       - rabbitmq
     restart: "always"
     volumes:
-      - ./reports:/reports # Bind mount the report schemas folder
+      - ./reports:/app/reports # Bind mount the report schemas folder
 
   couchbase:
     image: couchbase

--- a/pstatus-graphql-ktor/build.gradle
+++ b/pstatus-graphql-ktor/build.gradle
@@ -113,6 +113,9 @@ ktor {
 }
 
 jib {
+    container {
+        workingDirectory = '/app'
+    }
     from {
         auth {
             username = System.getenv("DOCKERHUB_USERNAME") ?: ""

--- a/pstatus-report-sink-ktor/build.gradle
+++ b/pstatus-report-sink-ktor/build.gradle
@@ -102,6 +102,9 @@ test {
 }
 
 jib {
+    container {
+        workingDirectory = '/app'
+    }
     from {
         auth {
             username = System.getenv("DOCKERHUB_USERNAME") ?: ""

--- a/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-should-handle-removal-of-non-existent-schema-gracefully-remove-schema-gracefully
+++ b/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-should-handle-removal-of-non-existent-schema-gracefully-remove-schema-gracefully
@@ -1,1 +1,1 @@
-[{"message":"Schema file not found or could not be deleted: non-existent-schema.1.0.0.schema.json for schema: non-existent-schema, schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"InternalServerError"}}]
+[{"message":"Schema file not found or could not be deleted: non-existent-schema.1.0.0.schema.json for schema: non-existent-schema, schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-90ba5-lure-when-removing-a-schema---empty-schema-name-remove-schema-validation-failure
+++ b/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-90ba5-lure-when-removing-a-schema---empty-schema-name-remove-schema-validation-failure
@@ -1,1 +1,1 @@
-[{"message":"Schema file not found or could not be deleted: .1.0.0.schema.json for schema: , schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"InternalServerError"}}]
+[{"message":"Schema file not found or could not be deleted: .1.0.0.schema.json for schema: , schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-94bdf-e-when-removing-a-schema---empty-schema-version-remove-schema-validation-failure
+++ b/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-94bdf-e-when-removing-a-schema---empty-schema-version-remove-schema-validation-failure
@@ -1,1 +1,1 @@
-[{"message":"Schema file not found or could not be deleted: test-schema..schema.json for schema: test-schema, schemaVersion: ","locations":[],"path":["removeSchema"],"extensions":{"classification":"InternalServerError"}}]
+[{"message":"Schema file not found or could not be deleted: test-schema..schema.json for schema: test-schema, schemaVersion: ","locations":[],"path":["removeSchema"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-c706b-moving-a-schema---invalid-schema-version-format-remove-schema-validation-failure
+++ b/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-c706b-moving-a-schema---invalid-schema-version-format-remove-schema-validation-failure
@@ -1,1 +1,1 @@
-[{"message":"Schema file not found or could not be deleted: test-schema.1.0.schema.json for schema: test-schema, schemaVersion: 1.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"InternalServerError"}}]
+[{"message":"Schema file not found or could not be deleted: test-schema.1.0.schema.json for schema: test-schema, schemaVersion: 1.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-d5c15-ving-a-schema---invalid-schema-name-with-spaces-remove-schema-validation-failure
+++ b/test/playwright/tests/__snapshot__/removeSchema.spec.ts/removeSchema-mutation-validation-failures-shou-d5c15-ving-a-schema---invalid-schema-name-with-spaces-remove-schema-validation-failure
@@ -1,1 +1,1 @@
-[{"message":"Schema file not found or could not be deleted: test schema name.1.0.0.schema.json for schema: test schema name, schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"InternalServerError"}}]
+[{"message":"Schema file not found or could not be deleted: test schema name.1.0.0.schema.json for schema: test schema name, schemaVersion: 1.0.0","locations":[],"path":["removeSchema"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-file-name-gracefully-schema-not-found-invalid-schema-name-filename
+++ b/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-file-name-gracefully-schema-not-found-invalid-schema-name-filename
@@ -1,1 +1,1 @@
-[{"message":"./reports/non-existent-schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContentFromFilename"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/non-existent-schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContentFromFilename"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-file-name-version-gracefully-schema-not-found-invalid-schema-version-filename
+++ b/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-file-name-version-gracefully-schema-not-found-invalid-schema-version-filename
@@ -1,1 +1,1 @@
-[{"message":"./reports/base.999.schema.json (No such file or directory)","locations":[],"path":["schemaContentFromFilename"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/base.999.schema.json (No such file or directory)","locations":[],"path":["schemaContentFromFilename"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-name-gracefully-schema-not-found-invalid-schema-name
+++ b/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-name-gracefully-schema-not-found-invalid-schema-name
@@ -1,1 +1,1 @@
-[{"message":"./reports/non-existent-schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/non-existent-schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-version-gracefully-schema-not-found-invalid-schema-version
+++ b/test/playwright/tests/__snapshot__/schemaContent.spec.ts/schemaContent-query-handles-invalid-schema-version-gracefully-schema-not-found-invalid-schema-version
@@ -1,1 +1,1 @@
-[{"message":"./reports/base.999.999.999.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/base.999.999.999.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/schemaLoaderInfo.spec.ts/schemaLoaderInfo-Query-matches-the-expected-snapshot-for-enviromnent-local-schemaLoaderInfo.json
+++ b/test/playwright/tests/__snapshot__/schemaLoaderInfo.spec.ts/schemaLoaderInfo-Query-matches-the-expected-snapshot-for-enviromnent-local-schemaLoaderInfo.json
@@ -1,1 +1,1 @@
-{"loaderType":"file_system","location":"/reports"}
+{"loaderType":"file_system","location":"reports"}

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-01c4b-ed-creating-a-schema---schema-version-with-text-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-01c4b-ed-creating-a-schema---schema-version-with-text-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-emoji-version.a.b.c.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-emoji-version.a.b.c.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-1b275-ned-creating-a-schema---schema-name-with-spaces-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-1b275-ned-creating-a-schema---schema-name-with-spaces-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test schema name with spaces.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test schema name with spaces.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-293a5-ng-a-schema---schema-version-with-too-many-dots-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-293a5-ng-a-schema---schema-version-with-too-many-dots-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-too-many-dots-version.1.2.3.4.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-too-many-dots-version.1.2.3.4.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-497c5-ing-a-schema---schema-version-with-too-few-dots-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-497c5-ing-a-schema---schema-version-with-too-few-dots-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-too-few-dots-version.1.2.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-too-few-dots-version.1.2.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-4ccba-chema---schema-version-with-invalid-punctuation-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-4ccba-chema---schema-version-with-invalid-punctuation-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-invalid-punctuation.1.0.​.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-invalid-punctuation.1.0.​.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-73ea3-a-schema---schema-version-with-emoji-characters-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-73ea3-a-schema---schema-version-with-emoji-characters-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-emoji-version.1.0.⛔.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-emoji-version.1.0.⛔.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-7dd66-ed-creating-a-schema---schema-name-empty-string-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-7dd66-ed-creating-a-schema---schema-name-empty-string-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-814f2-efined-creating-a-schema---schema-name-with-dot-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-814f2-efined-creating-a-schema---schema-name-with-dot-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/schema.2-with-dot.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/schema.2-with-dot.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-9209c-eating-a-schema---schema-version-with-backslash-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-9209c-eating-a-schema---schema-version-with-backslash-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-version-backslash.1\\0\\0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-version-backslash.1\\0\\0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-92d1a-ating-a-schema---schema-name-with-forward-slash-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-92d1a-ating-a-schema---schema-name-with-forward-slash-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/schema/test/name.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/schema/test/name.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-97f51-reating-a-schema---schema-version-ends-with-dot-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-97f51-reating-a-schema---schema-version-ends-with-dot-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-multi-version-dot.1.0..schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-multi-version-dot.1.0..schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-9ae05-chema---schema-name-with-path-traversal-attempt-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-9ae05-chema---schema-name-with-path-traversal-attempt-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/../schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/../schema.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-ab686--creating-a-schema---schema-name-with-backslash-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-ab686--creating-a-schema---schema-name-with-backslash-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/schema\\test\\name.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/schema\\test\\name.1.0.0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-b272a--creating-a-schema---schema-version-with-spaces-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-b272a--creating-a-schema---schema-version-with-spaces-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-version-spaces.1 0 0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-version-spaces.1 0 0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-b364c-ng-a-schema---schema-version-with-forward-slash-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-b364c-ng-a-schema---schema-version-with-forward-slash-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/test-schema-version-slash.1/0/0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/test-schema-version-slash.1/0/0.schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]

--- a/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-d1d28-creating-a-schema---schema-version-empty-string-schema-get-content-failed
+++ b/test/playwright/tests/__snapshot__/upsertSchema.spec.ts/upsertSchema-mutation-validation-failures-shou-d1d28-creating-a-schema---schema-version-empty-string-schema-get-content-failed
@@ -1,1 +1,1 @@
-[{"message":"/reports/schema-version-empty-string..schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]
+[{"message":"reports/schema-version-empty-string..schema.json (No such file or directory)","locations":[],"path":["schemaContent"],"extensions":{"classification":"FileNotFoundException"}}]


### PR DESCRIPTION
### Overview
There is currently a mismatch in the `reports` folder path when running Playwright locally versus in containerized environments. Locally, the `reports` folder resides in the working directory, while in the containers, it is located at the root. This inconsistency forces us to choose between successful local runs or container runs.

The solution is to align the container's working directory with the local setup, so both environments reference the `reports` folder using the same relative path.

### Summary of Changes
- Set the working directory to `/app` for both the `graphql` and `report-sink` container images.
- Updated Dockerfiles to mount local schema paths into the `/app` directory.
- Modified the Playwright `upsertSchema` snapshots to remove the leading slash from the `reports` folder path.