### PR TITLE
Fixed issues with upload metrics queries used in workflow

### DIFF
--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/query/UploadDurationQuery.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/query/UploadDurationQuery.kt
@@ -27,9 +27,7 @@ class UploadDurationQuery private constructor(
     }
 
     override fun buildSql(): String {
-        val querySB = StringBuilder()
-
-        querySB.append("""
+        return """
             SELECT RAW ARRAY_AGG(duration) 
             FROM (
                 SELECT 
@@ -39,17 +37,11 @@ class UploadDurationQuery private constructor(
                     AS duration
                 FROM $collectionName $cVar
                 WHERE ${cPrefix}stageInfo.action IN ['${StageAction.METADATA_VERIFY}', '${StageAction.FILE_DELIVERY}']
-                """)
-
-        querySB.append(whereClause(utcDateToRun))
-
-        querySB.append("""
+                    ${whereClause(utcDateToRun, prefix = "AND")}
                 GROUP BY ${cPrefix}uploadId
             ) subquery
             WHERE duration IS NOT NULL;
-        """)
-
-        return querySB.toString().trimIndent()
+        """.trimIndent()
     }
 
     /**

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/query/UploadMetricsQuery.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/query/UploadMetricsQuery.kt
@@ -28,9 +28,7 @@ class UploadMetricsQuery private constructor(
     }
 
     override fun buildSql(): String {
-        val querySB = StringBuilder()
-
-        querySB.append("""
+        return """
             SELECT 
                 -- Upload minimum delta
                 MIN(upload_delta) AS minUploadDeltaInMillis,
@@ -108,16 +106,10 @@ class UploadMetricsQuery private constructor(
             
                 FROM $collectionName $cVar
                 WHERE ${cPrefix}stageInfo.action IN ${openBkt}'${StageAction.METADATA_VERIFY}', '${StageAction.UPLOAD_COMPLETED}', '${StageAction.UPLOAD_STATUS}', '${StageAction.FILE_DELIVERY}'${closeBkt}
-            """)
-
-        querySB.append(whereClause(utcDateToRun))
-
-        querySB.append("""
+                    ${whereClause(utcDateToRun, prefix = "AND")}
                 GROUP BY ${cPrefix}uploadId
             ) AS upload_metrics;
-        """)
-
-        return querySB.toString().trimIndent()
+        """.trimIndent()
     }
 
     fun run() = runQuery(UploadMetrics::class.java).first()


### PR DESCRIPTION
### Summary of changes
- Fixed two queries used in the upload digest workflow when the data stream id(s) and data stream route(s) are provided.

### Testing Steps
1. Pull the `latest` tag quay image for the `notifications-workflow` container.
2. Create an upload digest workflow without a data stream id or data stream route and verify works. (This worked before)
3. Unsubscribe to the above workflow and check that it has been successfully canceled.
4. Repeat steps 3 and 4, but this time with a data stream id and route. This did not work before and is now fixed.