### PR TITLE
Phdo 424/couchbase metrics

### DIFF
--- a/configs/prometheus/prometheus.yml
+++ b/configs/prometheus/prometheus.yml
@@ -13,3 +13,13 @@ scrape_configs:
   - job_name: "otel-col"
     static_configs:
       - targets: ["otelcol:8889"]
+  - job_name: "couchbase-otel-col"
+    metrics_path: /metrics
+    static_configs:
+      - targets: [ "couchbase:8091" ]
+    basic_auth:
+      username: "admin"
+      password: "password"
+    scheme: http
+#    scrape_timeout: 5s
+    fallback_scrape_protocol: PrometheusText1.0.0

--- a/configs/prometheus/prometheus.yml
+++ b/configs/prometheus/prometheus.yml
@@ -21,5 +21,4 @@ scrape_configs:
       username: "admin"
       password: "password"
     scheme: http
-#    scrape_timeout: 5s
     fallback_scrape_protocol: PrometheusText1.0.0

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -3,7 +3,7 @@ services:
     image: grafana/tempo
     container_name: tempo
     networks:
-      - observability
+      - shared
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./configs/tempo.yaml:/etc/tempo.yaml
@@ -17,8 +17,7 @@ services:
     image: prom/prometheus
     container_name: prometheus
     networks:
-      - observability
-      - core-services
+      - shared
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     ports:
@@ -31,7 +30,7 @@ services:
     image: grafana/grafana
     container_name: grafana
     networks:
-      - observability
+      - shared
     ports:
       - 3000:3000
     restart: unless-stopped

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -2,6 +2,8 @@ services:
   tempo:
     image: grafana/tempo
     container_name: tempo
+    networks:
+      - observability
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./configs/tempo.yaml:/etc/tempo.yaml
@@ -14,6 +16,8 @@ services:
   prometheus:
     image: prom/prometheus
     container_name: prometheus
+    networks:
+      - observability
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     ports:
@@ -25,6 +29,8 @@ services:
   grafana:
     image: grafana/grafana
     container_name: grafana
+    networks:
+      - observability
     ports:
       - 3000:3000
     restart: unless-stopped
@@ -37,6 +43,7 @@ services:
     image: otel/opentelemetry-collector-contrib
     container_name: otelcol
     networks:
+      - observability
       - core-services
       - temporal-network
     volumes:
@@ -54,6 +61,9 @@ volumes:
   prom-data:
 
 networks:
+  observability:
+    driver: bridge
+    name: observability
   core-services:
     external: true
   temporal-network:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -18,6 +18,7 @@ services:
     container_name: prometheus
     networks:
       - observability
+      - core-services
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
     ports:

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/cosmos/CosmosRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/cosmos/CosmosRepository.kt
@@ -2,6 +2,7 @@ package gov.cdc.ocio.database.cosmos
 
 import gov.cdc.ocio.database.health.HealthCheckCosmosDb
 import gov.cdc.ocio.database.persistence.Collection
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import gov.cdc.ocio.types.health.HealthCheckSystem
 
@@ -43,13 +44,13 @@ class CosmosRepository(
     private val notificationSubscriptionsContainer =
         CosmosContainerManager.initDatabaseContainer(uri, authKey, notificationSubscriptionsContainerName, partitionKey)
 
-    override var reportsCollection = CosmosCollection(reportsContainer) as Collection
+    override var reportsCollection = CollectionDataFetcher(CosmosCollection(reportsContainer) as Collection)
 
     override var reportsDeadLetterCollection =
-        CosmosCollection(reportsDeadLetterContainer) as Collection
+        CollectionDataFetcher(CosmosCollection(reportsDeadLetterContainer) as Collection)
 
     override var notificationSubscriptionsCollection =
-        CosmosCollection(notificationSubscriptionsContainer) as Collection
+        CollectionDataFetcher(CosmosCollection(notificationSubscriptionsContainer) as Collection)
 
     override var healthCheckSystem = HealthCheckCosmosDb(
         system,

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/couchbase/CouchbaseRepository.kt
@@ -9,6 +9,7 @@ import com.couchbase.client.java.Scope
 import com.couchbase.client.java.manager.collection.CreateCollectionSettings
 import com.couchbase.client.metrics.opentelemetry.OpenTelemetryMeter
 import gov.cdc.ocio.database.health.HealthCheckCouchbaseDb
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import gov.cdc.ocio.types.adapters.NotificationTypeAdapter
 import gov.cdc.ocio.types.health.HealthCheckSystem
@@ -93,27 +94,30 @@ class CouchbaseRepository(
         notificationSubscriptionsCouchbaseCollection = scope.collection(notificationSubscriptionsCollectionName)
     }
 
-    override var reportsCollection =
+    override var reportsCollection = CollectionDataFetcher(
         CouchbaseCollection(
             reportsCollectionName,
             scope,
             reportsCouchbaseCollection
         ) as Collection
+    )
 
-    override var reportsDeadLetterCollection =
+    override var reportsDeadLetterCollection = CollectionDataFetcher(
         CouchbaseCollection(
             reportsDeadLetterCollectionName,
             scope,
             reportsDeadLetterCouchbaseCollection
         ) as Collection
+    )
 
-    override var notificationSubscriptionsCollection =
+    override var notificationSubscriptionsCollection = CollectionDataFetcher(
         CouchbaseCollection(
             notificationSubscriptionsCollectionName,
             scope,
             notificationSubscriptionsCouchbaseCollection,
             typeAdapters = mapOf(Notification::class.java to NotificationTypeAdapter())
         ) as Collection
+    )
 
     override var healthCheckSystem = HealthCheckCouchbaseDb(system) as HealthCheckSystem
 

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/dynamo/DynamoRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/dynamo/DynamoRepository.kt
@@ -5,6 +5,7 @@ import gov.cdc.ocio.database.health.HealthCheckDynamoDb
 import gov.cdc.ocio.database.persistence.Collection
 import gov.cdc.ocio.database.models.Report
 import gov.cdc.ocio.database.models.ReportDeadLetter
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import gov.cdc.ocio.types.health.HealthCheckSystem
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
@@ -48,27 +49,32 @@ class DynamoRepository(
 
     private val notificationSubscriptionsTableName = "$tablePrefix-notification-subscriptions".lowercase()
 
-    override var reportsCollection =
+    override var reportsCollection = CollectionDataFetcher(
         DynamoCollection(
             ddbClient,
             ddbEnhancedClient,
             reportsTableName,
             Report::class.java
         ) as Collection
+    )
 
-    override var reportsDeadLetterCollection = DynamoCollection(
-        ddbClient,
-        ddbEnhancedClient,
-        reportsDeadLetterTableName,
-        ReportDeadLetter::class.java
-    ) as Collection
+    override var reportsDeadLetterCollection = CollectionDataFetcher(
+        DynamoCollection(
+            ddbClient,
+            ddbEnhancedClient,
+            reportsDeadLetterTableName,
+            ReportDeadLetter::class.java
+        ) as Collection
+    )
 
-    override var notificationSubscriptionsCollection = DynamoCollection(
-        ddbClient,
-        ddbEnhancedClient,
-        notificationSubscriptionsTableName,
-        Any::class.java // TODO(This needs to be replaced!)
-    ) as Collection
+    override var notificationSubscriptionsCollection = CollectionDataFetcher(
+        DynamoCollection(
+            ddbClient,
+            ddbEnhancedClient,
+            notificationSubscriptionsTableName,
+            Any::class.java // TODO(This needs to be replaced!)
+        ) as Collection
+    )
 
     /**
      * Dynamodb implementation of converting the content map to a JsonNode.

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
@@ -1,0 +1,141 @@
+package gov.cdc.ocio.database.persistence
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import kotlin.time.measureTimedValue
+
+/**
+ * A class that provides telemetry functionality for actions performed on a NoSQL collection.
+ * It extends the Collection interface and acts as a decorator to measure performance metrics
+ * such as latency for retrieving items or querying items in the underlying collection.
+ *
+ * @constructor Creates an instance of CollectionDataFetcher with a delegate Collection.
+ * @param delegate The underlying collection implementation that this class wraps.
+ */
+class CollectionDataFetcher(
+    private val delegate: Collection
+) : Collection {
+
+    private val meter = GlobalOpenTelemetry.get().getMeter(delegate.collectionNameForQuery)
+
+    /**
+     * A histogram instrument used to record the latency of get item requests.
+     *
+     * The histogram measures the time taken, in milliseconds, to retrieve an item
+     * from the database. It is configured as a long-value histogram for precise
+     * measurement of time durations. This instrument is primarily utilized to
+     * collect performance metrics for monitoring and analysis purposes.
+     */
+    private val getItemLatencyHistogram = meter
+        .histogramBuilder("get_item_request_latency")
+        .setDescription("Time taken to get the item from the database")
+        .setUnit("ms")
+        .ofLongs()
+        .build()
+
+    /**
+     * A histogram metric used to record the latency, in milliseconds, of
+     * querying items from the database. This metric tracks the time it takes to
+     * fulfill a query request by measuring the elapsed duration for each query operation.
+     */
+    private val queryItemsLatencyHistogram = meter
+        .histogramBuilder("query_items_request_latency")
+        .setDescription("Time taken to get the query items from the database")
+        .setUnit("ms")
+        .ofLongs()
+        .build()
+
+    /**
+     * A histogram metric for measuring the latency of item creation requests.
+     *
+     * This metric tracks the time, in milliseconds, taken to create an item in the database.
+     */
+    private val createItemLatencyHistogram = meter
+        .histogramBuilder("create_item_request_latency")
+        .setDescription("Time taken to create an item in the database")
+        .setUnit("ms")
+        .ofLongs()
+        .build()
+
+    /**
+     * Histogram metric for tracking the latency of delete item requests.
+     *
+     * The metric records the time taken to delete an item from the database,
+     * measured in milliseconds.
+     */
+    private val deleteItemLatencyHistogram = meter
+        .histogramBuilder("delete_item_request_latency")
+        .setDescription("Time taken to delete an item in the database")
+        .setUnit("ms")
+        .ofLongs()
+        .build()
+
+    /**
+     * Retrieves a specific item identified by its ID and type.
+     *
+     * @param id the unique identifier of the item to be retrieved
+     * @param classType the class type of the item to be retrieved, used for deserialization
+     * @return the retrieved item of type T, or null if not found
+     */
+    override fun <T> getItem(id: String, classType: Class<T>?): T? {
+        val (result, duration) = measureTimedValue {
+            delegate.getItem(id, classType)
+        }
+        getItemLatencyHistogram.record(duration.inWholeMilliseconds)
+        return result
+    }
+
+    /**
+     * Queries items in the collection based on the specified query and class type.
+     *
+     * @param query The query string used to filter items in the collection.
+     * @param classType The class type of the items to be retrieved, used for deserialization.
+     * @return A list of items of type T that match the query criteria.
+     */
+    override fun <T> queryItems(query: String?, classType: Class<T>?): List<T> {
+        val (result, duration) = measureTimedValue {
+            delegate.queryItems(query, classType)
+        }
+        queryItemsLatencyHistogram.record(duration.inWholeMilliseconds)
+        return result
+    }
+
+    /**
+     * Creates a new item in the collection.
+     *
+     * @param id the unique identifier of the item to be created
+     * @param item the item to be created
+     * @param classType the class type of the item, used for serialization
+     * @param partitionKey the partition key for the item, or null if not applicable
+     * @return true if the item is successfully created, false otherwise
+     */
+    override fun <T> createItem(id: String, item: T, classType: Class<T>, partitionKey: String?): Boolean {
+        val (result, duration) = measureTimedValue {
+            delegate.createItem(id, item, classType, partitionKey)
+        }
+        createItemLatencyHistogram.record(duration.inWholeMilliseconds)
+        return result
+    }
+
+    /**
+     * Deletes an item from the collection based on its identifier and partition key.
+     *
+     * @param itemId the unique identifier of the item to be deleted
+     * @param partitionKey the partition key associated with the item, or null if not applicable
+     * @return true if the item was successfully deleted, false otherwise
+     */
+    override fun deleteItem(itemId: String?, partitionKey: String?): Boolean {
+        val (result, duration) = measureTimedValue {
+            delegate.deleteItem(itemId, partitionKey)
+        }
+        deleteItemLatencyHistogram.record(duration.inWholeMilliseconds)
+        return result
+    }
+
+    override val collectionVariable = delegate.collectionVariable
+
+    override val collectionVariablePrefix = delegate.collectionVariablePrefix
+
+    override val collectionNameForQuery = delegate.collectionNameForQuery
+
+    override val collectionElementForQuery = delegate.collectionElementForQuery
+}

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/ProcessingStatusRepository.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/ProcessingStatusRepository.kt
@@ -19,13 +19,13 @@ abstract class ProcessingStatusRepository {
     val system = "Database"
 
     // Common interface for the reports collection
-    open lateinit var reportsCollection: Collection
+    open lateinit var reportsCollection: CollectionDataFetcher
 
     // Common interface for the reports deadletter collection
-    open lateinit var reportsDeadLetterCollection: Collection
+    open lateinit var reportsDeadLetterCollection: CollectionDataFetcher
 
     // Common interface for the notification subscriptions collection
-    open lateinit var notificationSubscriptionsCollection: Collection
+    open lateinit var notificationSubscriptionsCollection: CollectionDataFetcher
 
     abstract var healthCheckSystem: HealthCheckSystem
 

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/GraphQL.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/GraphQL.kt
@@ -10,6 +10,7 @@ import io.ktor.server.auth.*
 import io.ktor.server.config.*
 import io.ktor.server.routing.*
 import io.ktor.server.websocket.*
+import io.opentelemetry.api.GlobalOpenTelemetry
 import java.time.Duration
 import kotlin.time.toKotlinDuration
 
@@ -66,6 +67,15 @@ fun Application.graphQLModule() {
         }
         engine {
             exceptionHandler = CustomGraphQLExceptionHandler()
+
+            val graphqlOperationCounter = GlobalOpenTelemetry.get()
+                .meterBuilder("pstatus-graphql-meter")
+                .build()
+                .counterBuilder("graphql_operation_count")
+                .setDescription("Count of GraphQL queries and mutations")
+                .setUnit("1")
+                .build()
+            instrumentations = listOf(MetricsInstrumentation(graphqlOperationCounter))
         }
     }
 

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/MetricsInstrumentation.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/MetricsInstrumentation.kt
@@ -1,0 +1,71 @@
+package gov.cdc.ocio.processingstatusapi.plugins
+
+import graphql.execution.instrumentation.*
+import graphql.execution.instrumentation.parameters.InstrumentationValidationParameters
+import graphql.language.OperationDefinition
+import graphql.validation.ValidationError
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.LongCounter
+import graphql.language.Field
+
+
+/**
+ * MetricsInstrumentation is a custom GraphQL instrumentation implementation that tracks and reports
+ * metrics for GraphQL operations using OpenTelemetry.
+ *
+ * This class extends from SimplePerformantInstrumentation and overrides specific methods to add metrics
+ * counters for operations processed within the GraphQL server.
+ *
+ * @constructor Creates an instance of MetricsInstrumentation.
+ *
+ * @param graphqlOperationCounter A LongCounter object used to count the number of operations performed
+ * in the GraphQL API. The counter tracks both the types of operations (query, mutation, etc.)
+ * and the operation names.
+ */
+class MetricsInstrumentation(
+    private val graphqlOperationCounter: LongCounter
+) : SimplePerformantInstrumentation() {
+
+    /**
+     * Begins the validation process for a GraphQL instrumentation, processes the provided operation definition,
+     * updates relevant metrics, and returns a no-op instrumentation context for validation errors.
+     *
+     * @param parameters the parameters containing the GraphQL request document and associated information, or null if unavailable.
+     * @param state the state shared across different phases of instrumentation, or null if not provided.
+     * @return an instance of InstrumentationContext that tracks the validation process for a list of validation errors.
+     */
+    override fun beginValidation(
+        parameters: InstrumentationValidationParameters?,
+        state: InstrumentationState?
+    ): InstrumentationContext<List<ValidationError>> {
+        val document = parameters?.document
+
+        // Get the first operation definition (GraphQL allows multiple, but you usually only have one)
+        val operationDefinition = document?.definitions
+            ?.filterIsInstance<OperationDefinition>()
+            ?.firstOrNull()
+
+        val operationName = operationDefinition?.selectionSet?.selections
+                ?.filterIsInstance<Field>()
+                ?.firstOrNull()
+                ?.name
+            ?: "Unknown"
+
+        val operationType = operationDefinition?.operation?.name ?: "Unknown"
+
+        graphqlOperationCounter.add(
+            1,
+            Attributes.of(
+                AttributeKey.stringKey("operation"), operationName,
+                AttributeKey.stringKey("operation_type"), operationType
+            )
+        )
+
+        // Return a no-op context
+        return object : InstrumentationContext<List<ValidationError>> {
+            override fun onDispatched() {}
+            override fun onCompleted(result: List<ValidationError>?, t: Throwable?) {}
+        }
+    }
+}

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/MetricsInstrumentation.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/plugins/MetricsInstrumentation.kt
@@ -31,7 +31,8 @@ class MetricsInstrumentation(
      * Begins the validation process for a GraphQL instrumentation, processes the provided operation definition,
      * updates relevant metrics, and returns a no-op instrumentation context for validation errors.
      *
-     * @param parameters the parameters containing the GraphQL request document and associated information, or null if unavailable.
+     * @param parameters the parameters containing the GraphQL request document and associated information, or null
+     * if unavailable.
      * @param state the state shared across different phases of instrumentation, or null if not provided.
      * @return an instance of InstrumentationContext that tracks the validation process for a list of validation errors.
      */
@@ -64,8 +65,29 @@ class MetricsInstrumentation(
 
         // Return a no-op context
         return object : InstrumentationContext<List<ValidationError>> {
-            override fun onDispatched() {}
-            override fun onCompleted(result: List<ValidationError>?, t: Throwable?) {}
+            /**
+             * Handles the dispatching phase of the instrumentation process.
+             *
+             * This method is invoked when an operation or event reaches the dispatched
+             * state within the GraphQL instrumentation pipeline. Typically, this method
+             * can be used to perform actions or update metrics right after an operation
+             * is dispatched, without waiting for its completion.
+             *
+             * The default implementation is empty.
+             */
+            override fun onDispatched() { /* no-op */ }
+
+            /**
+             * Invoked when the process involving the list of validation errors is completed. This method handles
+             * the post-completion behavior within the GraphQL instrumentation pipeline. It can be used to perform
+             * logging, error handling, or updating relevant metrics after the validation process concludes.
+             *
+             * @param result an optional list of validation errors generated during the validation process, or null if
+             * no errors occurred.
+             * @param t an optional throwable representing any exception that might have occurred during the process,
+             * or null if no exception occurred.
+             */
+            override fun onCompleted(result: List<ValidationError>?, t: Throwable?) { /* no-op */ }
         }
     }
 }

--- a/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
+++ b/pstatus-report-sink-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/Application.kt
@@ -17,14 +17,10 @@ import io.ktor.server.config.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
-import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.instrumentation.ktor.v2_0.KtorServerTelemetry
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk
-import io.opentelemetry.sdk.metrics.Aggregation
 import io.opentelemetry.sdk.metrics.InstrumentSelector
 import io.opentelemetry.sdk.metrics.InstrumentType
-import io.opentelemetry.sdk.metrics.View
 import io.opentelemetry.semconv.ServiceAttributes
 import org.koin.core.KoinApplication
 import org.koin.ktor.plugin.Koin
@@ -93,7 +89,7 @@ fun Application.module() {
             old.registerView(
                 InstrumentSelector.builder().setType(InstrumentType.HISTOGRAM).build(), Otel.getDefaultHistogramView())
         }
-    val otel: OpenTelemetry = builder.build().openTelemetrySdk
+    val otel = builder.build().openTelemetrySdk
     install(KtorServerTelemetry) {
         setOpenTelemetry(otel)
     }


### PR DESCRIPTION
### Summary of changes
- Added server-side Couchbase database metrics collections to the Prometheus configuration
- Added GraphQL queries and mutation metrics via GraphQL instrumentation
- Added generic metrics to the database library to capture database call timings regardless of the database (couchbase, dynamo, cosmos, etc.)