### PR TITLE
playwright-graphql getSubmissionDetails tests

### DIFF
--- a/test/playwright/fixtures/dataGenerator.ts
+++ b/test/playwright/fixtures/dataGenerator.ts
@@ -106,7 +106,8 @@ export function createUploadReportStarted(report?: UploadReport): UploadReport {
     
     const newReport: UploadReport = {
         ...report,
-        content: createContentUploadStarted()
+        content: createContentUploadStarted(),
+        stage_info: createStageInfoStarted()
     }
     return newReport
 }
@@ -124,7 +125,8 @@ export function createUploadReportCompleted(report?: UploadReport): UploadReport
     report = report || createUploadReport()
     const newReport: UploadReport = {
         ...report,
-        content: createContentUploadCompleted()
+        content: createContentUploadCompleted(),
+        stage_info: createStageInfoCompleted()
     }
     return newReport
 }
@@ -151,6 +153,33 @@ export function createStageInfo(date: Date = new Date()) {
 
     return stage_info
 }
+
+export function createStageInfoStarted(date: Date = new Date()) {
+    const stage_info =  {
+        service: "UPLOAD API",
+        action: "upload-started",
+        version: "0.0.49-SNAPSHOT",
+        status: Status.SUCCESS,
+        start_processing_time: getFormattedDate(addSeconds(date, 10)),
+        end_processing_time: getFormattedDate(addSeconds(date, 20))
+    }
+
+    return stage_info
+}
+
+export function createStageInfoCompleted(date: Date = new Date()) {
+    const stage_info =  {
+        service: "UPLOAD API",
+        action: "upload-completed",
+        version: "0.0.49-SNAPSHOT",
+        status: Status.SUCCESS,
+        start_processing_time: getFormattedDate(addSeconds(date, 10)),
+        end_processing_time: getFormattedDate(addSeconds(date, 20))
+    }
+
+    return stage_info
+}
+
 
 export function createStageInfoWithWarning(date: Date = new Date()) {
     const stage_info_warn = {

--- a/test/playwright/fixtures/gql.ts
+++ b/test/playwright/fixtures/gql.ts
@@ -1,12 +1,12 @@
-import { test as baseTest, expect, request, APIRequestContext } from '@playwright/test';
+import { test as baseTest, expect as baseExpect, request, APIRequestContext } from '@playwright/test';
 import { getClient, RequesterOptions} from '@gql';
 import dotenv from 'dotenv';
 import dataGenerator from './dataGenerator';
 import { NotificationHelper } from './notificationHelper';
 import { GraphQLError } from 'graphql';
 import { SchemaHelper } from './schemaHelper';
+import { ReportHelper } from './reportHelper';
 
-export { expect };
 export type GraphQLErrorResponse = { errors: GraphQLError[] };
 
 dotenv.config({ path: '../.env' });
@@ -19,6 +19,7 @@ type WorkerFixtures = {
     dataGenerator: typeof dataGenerator;
     notificationHelper: NotificationHelper;
     schemaHelper: SchemaHelper;
+    reportHelper: ReportHelper;
 };
 
 export const test = baseTest.extend<{}, WorkerFixtures>({
@@ -53,5 +54,40 @@ export const test = baseTest.extend<{}, WorkerFixtures>({
         async ({ gql }, use) => {
             await use(new SchemaHelper(gql));
         }, { auto: false, scope: 'worker' }
+    ],
+    reportHelper: [
+        async ({ gql }, use) => {
+            await use(new ReportHelper(gql));
+        }, { auto: false, scope: 'worker' }
     ]
 });
+
+export const expect = baseExpect.extend({
+    toBeRecentInSeconds: (received: any, threshold: number = 30) => {
+        try {
+            const now = new Date()
+            const receivedDate: Date = new Date(received)
+            const diff = now.getTime() - receivedDate.getTime()
+            const diffInSeconds = diff / (1000)
+            const pass =  diffInSeconds < threshold
+
+            if (pass) {
+                return {
+                    message: () => `passed`,
+                    pass: true
+                }
+            } else {
+                return {
+                    message: () => `expected ${received} to be recent to now ${now} within ${threshold} seconds.  Diff: ${diffInSeconds} seconds`,
+                    pass: false
+                } 
+            }
+        } catch (error) {
+            return {
+                message: () => `Exception thrown`,
+                matcherResult: error,
+                pass: false
+            }
+        }
+    }
+})

--- a/test/playwright/fixtures/reportHelper.ts
+++ b/test/playwright/fixtures/reportHelper.ts
@@ -112,7 +112,7 @@ export class ReportHelper {
         uploadId: string,
         sortedBy: string,
         sortOrder: SortOrder,
-        expectedReportCount: number
+        expectedReportCount: number = 1
     ): Promise<GetSubmissionDetailsQuery> {
         let submissionDetailsResult: GetSubmissionDetailsQuery;
         await expect(async () => {

--- a/test/playwright/fixtures/reportHelper.ts
+++ b/test/playwright/fixtures/reportHelper.ts
@@ -2,7 +2,7 @@ import { test as base } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { GraphQLErrorResponse } from '@fixtures/gql';
 import dataGenerator, { UploadReport } from './dataGenerator';
-import { GetSubmissionDetailsQuery } from '@gql';
+import { GetSubmissionDetailsQuery, SortOrder } from '@gql';
 
 export class ReportHelper {
     constructor(private readonly gql: any) {}
@@ -106,6 +106,29 @@ export class ReportHelper {
             expect.soft(responseReport).toHaveProperty(mapping.response)
             expect.soft(responseValue, `Field ${mapping.response} does not match ${mapping.report}`).toBe(finalTestValue)
         })
+    }
+
+    async getSubmissionDetailsAndValidate(
+        uploadId: string,
+        sortedBy: string,
+        sortOrder: SortOrder,
+        expectedReportCount: number
+    ): Promise<GetSubmissionDetailsQuery> {
+        let submissionDetailsResult: GetSubmissionDetailsQuery;
+        await expect(async () => {
+            submissionDetailsResult = await this.gql.getSubmissionDetails({
+                uploadId,
+                reportsSortedBy: sortedBy,
+                sortOrder
+            })
+            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
+            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(expectedReportCount)
+            
+        }).toPass({
+            intervals: [1_000, 2_000, 5_000],
+        })
+
+        return submissionDetailsResult!;
     }
 }
 

--- a/test/playwright/fixtures/reportHelper.ts
+++ b/test/playwright/fixtures/reportHelper.ts
@@ -1,0 +1,121 @@
+import { test as base } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { GraphQLErrorResponse } from '@fixtures/gql';
+import dataGenerator, { UploadReport } from './dataGenerator';
+import { GetSubmissionDetailsQuery } from '@gql';
+
+export class ReportHelper {
+    constructor(private readonly gql: any) {}
+  
+    async createUploadCompleteReport(baseReport?: UploadReport) {
+        const report = await dataGenerator.createUploadReportCompleted(baseReport)
+        const createReportResult = await this.gql.upsertReport({
+            action: "create",
+            report: report
+        })
+        expect(createReportResult.upsertReport.result).toBe("SUCCESS")
+        return { completeReport: report, createCompleteReportResult: createReportResult }
+    }
+
+    async createUploadStartedReport() {
+        const report = await dataGenerator.createUploadReportStarted()
+        const createReportResult = await this.gql.upsertReport({
+            action: "create",
+            report: report
+        })
+        expect(createReportResult.upsertReport.result).toBe("SUCCESS")
+        return { startedReport: report, createStartedReportResult: createReportResult }
+    }
+
+    validateSubmissionDetailFields(submissionDetails: GetSubmissionDetailsQuery['getSubmissionDetails'], report: any) {
+        expect.soft(submissionDetails.dataProducerId).toBe(report.data_producer_id)
+        expect.soft(submissionDetails.dataStreamId).toBe(report.data_stream_id)
+        expect.soft(submissionDetails.dataStreamRoute).toBe(report.data_stream_route)
+        expect.soft(submissionDetails.filename).toBe(null)
+        expect.soft(submissionDetails.jurisdiction).toBe(report.jurisdiction)
+        expect.soft(submissionDetails.lastService).toBe(report.stage_info.service)
+        expect.soft(submissionDetails.senderId).toBe(report.sender_id)
+        expect.soft(submissionDetails.status).toBe("DELIVERED")
+        expect.soft(submissionDetails.uploadId).toBe(report.upload_id)
+        const expectedStageInfoAction = report.stage_info.action.toUpperCase().replace(/-/g, "_")
+        expect.soft(submissionDetails.lastAction).toBe(expectedStageInfoAction)
+        expect.soft(submissionDetails.dexIngestDateTime).toBeRecentInSeconds(5)
+    }
+
+    validateSubmissionDetailReport(submissionDetailsReports: GetSubmissionDetailsQuery['getSubmissionDetails']['reports'], originalReport: any) {
+        expect(submissionDetailsReports).toBeDefined()
+
+        const originalReportAction = originalReport.stage_info.action.toUpperCase().replace(/-/g, '_')
+
+        const foundReport = submissionDetailsReports!.filter(report => report.stageInfo?.action === originalReportAction)
+        expect(foundReport.length).toEqual(1)
+
+        const responseReport = foundReport[0]
+        expect.soft(new Date(responseReport.timestamp).getTime()).toBeRecentInSeconds(10)
+        expect.soft(responseReport.id).toBeDefined()
+        expect.soft(responseReport.reportId).toBeDefined()
+        expect.soft(responseReport.id).toBe(responseReport.reportId)
+
+        const fieldMappings: FieldMapping[] = [
+            { response: 'uploadId', report: 'upload_id' },
+            { response: 'dataStreamId', report: 'data_stream_id' },
+            { response: 'dataStreamRoute', report: 'data_stream_route' },
+            { response: 'jurisdiction', report: 'jurisdiction' },
+            { response: 'senderId', report: 'sender_id' },
+            { response: 'dataProducerId', report: 'data_producer_id' },
+            { response: 'contentType', report: 'content_type' },
+            { response: 'dexIngestDateTime', report: 'dex_ingest_date_time',
+                transform: (value: string) => null  // does not populate in response
+             },
+            { response: 'messageMetadata.messageUUID', report: 'message_metadata.message_uuid', 
+                transform: (value: string) => null  // does not populate in response
+            },
+            { response: 'messageMetadata.messageHash', report: 'message_metadata.message_hash', 
+                transform: (value: string) => null  // does not populate in response
+            },
+            { response: 'messageMetadata.aggregation', report: 'message_metadata.aggregation' },
+            { response: 'messageMetadata.messageIndex', report: 'message_metadata.message_index', 
+                transform: (value: string) => null  // does not populate in response
+            },
+            { response: 'stageInfo.service', report: 'stage_info.service' },
+            { response: 'stageInfo.action', report: 'stage_info.action',
+                transform: (value: string) => value.toUpperCase().replace(/-/g, '_')
+            },
+            { response: 'stageInfo.service', report: 'stage_info.service' },
+            { response: 'stageInfo.status', report: 'stage_info.status' },
+            { response: 'stageInfo.version', report: 'stage_info.version' },
+            //{ response: 'stageInfo.issues', report: 'stage_info.issues' },
+            { response: 'stageInfo.startProcessingTime', report: 'stage_info.start_processing_time', 
+                transform: (value: string) => null  // does not populate in response
+            },
+            { response: 'stageInfo.endProcessingTime', report: 'stage_info.end_processing_time', 
+                transform: (value: string) => null  // does not populate in response
+             },
+            { response: 'content.contentSchemaName', report: 'content.content_schema_name' },
+            { response: 'content.contentSchemaVersion', report: 'content.content_schema_version' },
+            { response: 'content.status', report: 'content.status' },
+            { response: 'data.dataField1', report: 'data.data_field1' },
+            { response: 'tags.tagField1', report: 'tags.tag_field1' },
+        ]
+
+        // Validate each mapped field
+        fieldMappings.forEach(mapping => {
+            const responseValue = getNestedValue(responseReport, mapping.response)
+            const originalReportValue = getNestedValue(originalReport, mapping.report)
+            const finalTestValue = mapping.transform ? mapping.transform(originalReportValue) : originalReportValue
+            expect.soft(responseReport).toHaveProperty(mapping.response)
+            expect.soft(responseValue, `Field ${mapping.response} does not match ${mapping.report}`).toBe(finalTestValue)
+        })
+    }
+}
+
+interface FieldMapping {
+    response: string;
+    report: string;
+    transform?: (value: any) => any;
+}
+
+const getNestedValue = (obj: any, path: string) => {
+    return path.split('.').reduce((acc, part) => acc?.[part], obj)
+}
+

--- a/test/playwright/tests/__snapshot__/getSubmissionDetails.spec.ts/GraphQL-getSubmissionDetails-returns-an-error-when-the-sort-field-is-not-a-valid-field-invalid-sort-field
+++ b/test/playwright/tests/__snapshot__/getSubmissionDetails.spec.ts/GraphQL-getSubmissionDetails-returns-an-error-when-the-sort-field-is-not-a-valid-field-invalid-sort-field
@@ -1,0 +1,1 @@
+{"errors":[{"message":"Reports can not be sorted by 'invalid-field'","locations":[],"path":["getSubmissionDetails"],"extensions":{"classification":"BadRequestException"}}]}

--- a/test/playwright/tests/getSubmissionDetails.spec.ts
+++ b/test/playwright/tests/getSubmissionDetails.spec.ts
@@ -8,8 +8,7 @@ test.describe('GraphQL getSubmissionDetails', () => {
         const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
             completeReport.upload_id,
             "timestamp",
-            SortOrder.Ascending,
-            1
+            SortOrder.Ascending
         )
 
         const submissionDetails = submissionDetailsResult.getSubmissionDetails
@@ -51,21 +50,28 @@ test.describe('GraphQL getSubmissionDetails', () => {
         expect(Date.parse(firstReport.timestamp)).toBeLessThan(Date.parse(secondReport.timestamp))
     })
 
-    test('returns submission details ordered by timestamp descending', async ({ gql, reportHelper }) => {
+    test('returns an error when the sort field is not a valid field', async ({ gql, reportHelper }) => {
         const { startedReport } = await reportHelper.createUploadStartedReport()
-        await reportHelper.createUploadCompleteReport(startedReport)
+        
+        const submissionDetailsResult = await gql.getSubmissionDetails({
+            uploadId: startedReport.upload_id,
+            reportsSortedBy: "invalid-field",
+            sortOrder: SortOrder.Ascending
+        }, {failOnEmptyData: false})
+        
+        expect(JSON.stringify(submissionDetailsResult)).toMatchSnapshot('invalid-sort-field')
+    })
 
-        const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
+
+    // This test is to ensure that the timestamp field can be sorted by with an alternate spelling
+    // It does not currently work and needs to be enabled later on when fixed
+    test.skip('can sort by timestamp with alternate spelling', async ({ gql, reportHelper }) => {
+        const { startedReport } = await reportHelper.createUploadStartedReport()
+        await reportHelper.getSubmissionDetailsAndValidate(
             startedReport.upload_id,
-            "timestamp",
-            SortOrder.Descending,
-            2
+            "Timestamp",
+            SortOrder.Descending
         )
-
-        const firstReport = submissionDetailsResult.getSubmissionDetails.reports![0]
-        const secondReport = submissionDetailsResult.getSubmissionDetails.reports![1]
-
-        expect(Date.parse(firstReport.timestamp)).toBeGreaterThan(Date.parse(secondReport.timestamp))
     })
 });
 

--- a/test/playwright/tests/getSubmissionDetails.spec.ts
+++ b/test/playwright/tests/getSubmissionDetails.spec.ts
@@ -1,102 +1,71 @@
 import { test, expect } from '@fixtures/gql';
-import { GetSubmissionDetailsQuery, SortOrder } from '@gql';
+import { SortOrder } from '@gql';
 test.describe('GraphQL getSubmissionDetails', () => {
 
     test('returns submission details for a simple upload report', async ({ gql, reportHelper }) => {
-        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport()
+        const { completeReport } = await reportHelper.createUploadCompleteReport()
 
-        let submissionDetailsResult: GetSubmissionDetailsQuery;
-        await expect(async () => {
-            submissionDetailsResult = await gql.getSubmissionDetails({
-                uploadId: completeReport.upload_id,
-                reportsSortedBy: "timestamp",
-                sortOrder: SortOrder.Ascending
-            })
-            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
-            
-        }).toPass({
-            intervals: [1_000, 2_000, 5_000],
-        })
+        const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
+            completeReport.upload_id,
+            "timestamp",
+            SortOrder.Ascending,
+            1
+        )
 
-        const submissionDetails = submissionDetailsResult!.getSubmissionDetails
+        const submissionDetails = submissionDetailsResult.getSubmissionDetails
         reportHelper.validateSubmissionDetailFields(submissionDetails, completeReport)
         reportHelper.validateSubmissionDetailReport(submissionDetails.reports, completeReport)
-        
     })
 
     test('returns submission details for an upload report with multiple reports', async ({ gql, reportHelper }) => {
-        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
-        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+        const { startedReport } = await reportHelper.createUploadStartedReport()
+        const { completeReport } = await reportHelper.createUploadCompleteReport(startedReport)
 
-        let submissionDetailsResult: GetSubmissionDetailsQuery;
-        await expect(async () => {
-            submissionDetailsResult = await gql.getSubmissionDetails({
-                uploadId: startedReport.upload_id,
-                reportsSortedBy: "timestamp",
-                sortOrder: SortOrder.Ascending
-            })
-            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
-            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
-            
-        }).toPass({
-            intervals: [1_000, 2_000, 5_000],
-        })
+        const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
+            startedReport.upload_id,
+            "timestamp",
+            SortOrder.Ascending,
+            2
+        )
 
-        const submissionDetails = submissionDetailsResult!.getSubmissionDetails
+        const submissionDetails = submissionDetailsResult.getSubmissionDetails
         reportHelper.validateSubmissionDetailFields(submissionDetails, completeReport)
         reportHelper.validateSubmissionDetailReport(submissionDetails.reports, startedReport)
         reportHelper.validateSubmissionDetailReport(submissionDetails.reports, completeReport)
-        
     })
 
     test('returns submission details ordered by timestamp ascending', async ({ gql, reportHelper }) => {
-        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
-        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+        const { startedReport } = await reportHelper.createUploadStartedReport()
+        await reportHelper.createUploadCompleteReport(startedReport)
 
-        let submissionDetailsResult: GetSubmissionDetailsQuery;
-        await expect(async () => {
-            submissionDetailsResult = await gql.getSubmissionDetails({
-                uploadId: startedReport.upload_id,
-                reportsSortedBy: "timestamp",
-                sortOrder: SortOrder.Ascending
-            })
-            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
-            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
-            
-        }).toPass({
-            intervals: [1_000, 2_000, 5_000],
-        })
+        const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
+            startedReport.upload_id,
+            "timestamp",
+            SortOrder.Ascending,
+            2
+        )
 
-        const firstReport = submissionDetailsResult!.getSubmissionDetails.reports![0]
-        const secondReport = submissionDetailsResult!.getSubmissionDetails.reports![1]
+        const firstReport = submissionDetailsResult.getSubmissionDetails.reports![0]
+        const secondReport = submissionDetailsResult.getSubmissionDetails.reports![1]
 
         expect(Date.parse(firstReport.timestamp)).toBeLessThan(Date.parse(secondReport.timestamp))
-
     })
 
     test('returns submission details ordered by timestamp descending', async ({ gql, reportHelper }) => {
-        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
-        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+        const { startedReport } = await reportHelper.createUploadStartedReport()
+        await reportHelper.createUploadCompleteReport(startedReport)
 
-        let submissionDetailsResult: GetSubmissionDetailsQuery;
-        await expect(async () => {
-            submissionDetailsResult = await gql.getSubmissionDetails({
-                uploadId: startedReport.upload_id,
-                reportsSortedBy: "timestamp",
-                sortOrder: SortOrder.Descending
-            })
-            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
-            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
-            
-        }).toPass({
-            intervals: [1_000, 2_000, 5_000],
-        })
+        const submissionDetailsResult = await reportHelper.getSubmissionDetailsAndValidate(
+            startedReport.upload_id,
+            "timestamp",
+            SortOrder.Descending,
+            2
+        )
 
-        const firstReport = submissionDetailsResult!.getSubmissionDetails.reports![0]
-        const secondReport = submissionDetailsResult!.getSubmissionDetails.reports![1]
+        const firstReport = submissionDetailsResult.getSubmissionDetails.reports![0]
+        const secondReport = submissionDetailsResult.getSubmissionDetails.reports![1]
 
         expect(Date.parse(firstReport.timestamp)).toBeGreaterThan(Date.parse(secondReport.timestamp))
-
     })
 });
 

--- a/test/playwright/tests/getSubmissionDetails.spec.ts
+++ b/test/playwright/tests/getSubmissionDetails.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@fixtures/gql';
+import { GetSubmissionDetailsQuery, SortOrder } from '@gql';
+test.describe('GraphQL getSubmissionDetails', () => {
+
+    test('returns submission details for a simple upload report', async ({ gql, reportHelper }) => {
+        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport()
+
+        let submissionDetailsResult: GetSubmissionDetailsQuery;
+        await expect(async () => {
+            submissionDetailsResult = await gql.getSubmissionDetails({
+                uploadId: completeReport.upload_id,
+                reportsSortedBy: "timestamp",
+                sortOrder: SortOrder.Ascending
+            })
+            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
+            
+        }).toPass({
+            intervals: [1_000, 2_000, 5_000],
+        })
+
+        const submissionDetails = submissionDetailsResult!.getSubmissionDetails
+        reportHelper.validateSubmissionDetailFields(submissionDetails, completeReport)
+        reportHelper.validateSubmissionDetailReport(submissionDetails.reports, completeReport)
+        
+    })
+
+    test('returns submission details for an upload report with multiple reports', async ({ gql, reportHelper }) => {
+        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
+        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+
+        let submissionDetailsResult: GetSubmissionDetailsQuery;
+        await expect(async () => {
+            submissionDetailsResult = await gql.getSubmissionDetails({
+                uploadId: startedReport.upload_id,
+                reportsSortedBy: "timestamp",
+                sortOrder: SortOrder.Ascending
+            })
+            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
+            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
+            
+        }).toPass({
+            intervals: [1_000, 2_000, 5_000],
+        })
+
+        const submissionDetails = submissionDetailsResult!.getSubmissionDetails
+        reportHelper.validateSubmissionDetailFields(submissionDetails, completeReport)
+        reportHelper.validateSubmissionDetailReport(submissionDetails.reports, startedReport)
+        reportHelper.validateSubmissionDetailReport(submissionDetails.reports, completeReport)
+        
+    })
+
+    test('returns submission details ordered by timestamp ascending', async ({ gql, reportHelper }) => {
+        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
+        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+
+        let submissionDetailsResult: GetSubmissionDetailsQuery;
+        await expect(async () => {
+            submissionDetailsResult = await gql.getSubmissionDetails({
+                uploadId: startedReport.upload_id,
+                reportsSortedBy: "timestamp",
+                sortOrder: SortOrder.Ascending
+            })
+            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
+            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
+            
+        }).toPass({
+            intervals: [1_000, 2_000, 5_000],
+        })
+
+        const firstReport = submissionDetailsResult!.getSubmissionDetails.reports![0]
+        const secondReport = submissionDetailsResult!.getSubmissionDetails.reports![1]
+
+        expect(Date.parse(firstReport.timestamp)).toBeLessThan(Date.parse(secondReport.timestamp))
+
+    })
+
+    test('returns submission details ordered by timestamp descending', async ({ gql, reportHelper }) => {
+        const { startedReport, createStartedReportResult } = await reportHelper.createUploadStartedReport()
+        const { completeReport, createCompleteReportResult } = await reportHelper.createUploadCompleteReport(startedReport)
+
+        let submissionDetailsResult: GetSubmissionDetailsQuery;
+        await expect(async () => {
+            submissionDetailsResult = await gql.getSubmissionDetails({
+                uploadId: startedReport.upload_id,
+                reportsSortedBy: "timestamp",
+                sortOrder: SortOrder.Descending
+            })
+            expect(submissionDetailsResult.getSubmissionDetails).toBeDefined()
+            expect(submissionDetailsResult.getSubmissionDetails.reports).toHaveLength(2)
+            
+        }).toPass({
+            intervals: [1_000, 2_000, 5_000],
+        })
+
+        const firstReport = submissionDetailsResult!.getSubmissionDetails.reports![0]
+        const secondReport = submissionDetailsResult!.getSubmissionDetails.reports![1]
+
+        expect(Date.parse(firstReport.timestamp)).toBeGreaterThan(Date.parse(secondReport.timestamp))
+
+    })
+});
+

--- a/test/playwright/tests/listReportSchemas.spec.ts
+++ b/test/playwright/tests/listReportSchemas.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@fixtures/gql';
+const environmentName = process.env.ENV || 'local';
 
 test.describe("listReportSchemas query", async () => {
   const expectedSchemas = [
@@ -13,7 +14,7 @@ test.describe("listReportSchemas query", async () => {
   ];
     
   expectedSchemas.forEach(expectedSchema => {
-    test(`matches snapshot for schema ${expectedSchema.schemaName}/${expectedSchema.version} in ${process.env.ENV}`, async ({ gql }, testInfo) => {
+    test(`matches snapshot for schema ${expectedSchema.schemaName}/${expectedSchema.version} in ${environmentName}`, async ({ gql }, testInfo) => {
       const response = await gql.listReportSchemas();
       
       expect(response.listReportSchemas.length).toBeGreaterThan(0);
@@ -26,7 +27,7 @@ test.describe("listReportSchemas query", async () => {
     });
   });
 
-  test(`validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+  test(`validates the response structure for environment: ${environmentName}`, async ({ gql }) => {
     const response = await gql.listReportSchemas();
     
     expect(Array.isArray(response.listReportSchemas)).toBe(true);

--- a/test/playwright/tests/schemaContent.spec.ts
+++ b/test/playwright/tests/schemaContent.spec.ts
@@ -1,5 +1,7 @@
-import { test, expect } from '@fixtures/gql';
+import { test, expect, GraphQLErrorResponse } from '@fixtures/gql';
 import complexSchema from '../fixtures/complex-schema.json';
+
+const environmentName = process.env.ENV || 'local';
 
 test.describe("schemaContent query", async () => {
     test.beforeAll(async ({ gql }) => {
@@ -29,7 +31,7 @@ test.describe("schemaContent query", async () => {
     ];
 
     expectedSchemas.forEach(expectedSchema => {
-        test(`matches snapshot for schema content ${expectedSchema.schemaName}/${expectedSchema.version} in ${process.env.ENV}`, async ({ gql }, testInfo) => {
+        test(`matches snapshot for schema content ${expectedSchema.schemaName}/${expectedSchema.version} in ${environmentName}`, async ({ gql }, testInfo) => {
             const response = await gql.schemaContent({
                 schemaName: expectedSchema.schemaName,
                 schemaVersion: expectedSchema.version
@@ -47,7 +49,8 @@ test.describe("schemaContent query", async () => {
         });
     });
 
-    test(`by schema name validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+
+    test(`by schema name validates the response structure for environment: ${environmentName}`, async ({ gql }) => {
         const response = await gql.schemaContent({
             schemaName: 'base',
             schemaVersion: '1.0.0'
@@ -57,7 +60,7 @@ test.describe("schemaContent query", async () => {
         expect(typeof response.schemaContent).toBe('object');
     });
 
-    test(`by schema file name validates the response structure for environment: ${process.env.ENV}`, async ({ gql }) => {
+    test(`by schema file name validates the response structure for environment: ${process.env.ENV || 'local'}`, async ({ gql }) => {
         const response = await gql.schemaContentFromFilename({
             schemaFilename: 'base.1.0.0.schema.json'
         });
@@ -70,7 +73,7 @@ test.describe("schemaContent query", async () => {
         const response = await gql.schemaContent({
             schemaName: 'non-existent-schema',
             schemaVersion: '1.0.0'
-        }, { failOnEmptyData: false });
+        }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
 
         expect(JSON.stringify(response.errors)).toMatchSnapshot("schema-not-found-invalid-schema-name");
     });
@@ -79,7 +82,7 @@ test.describe("schemaContent query", async () => {
         const response = await gql.schemaContent({
             schemaName: 'base',
             schemaVersion: '999.999.999'
-        }, { failOnEmptyData: false });
+        }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
 
         expect(JSON.stringify(response.errors)).toMatchSnapshot("schema-not-found-invalid-schema-version");
     });
@@ -87,7 +90,7 @@ test.describe("schemaContent query", async () => {
     test('handles invalid schema file name gracefully', async ({ gql }) => {
         const response = await gql.schemaContentFromFilename({
             schemaFilename: 'non-existent-schema.1.0.0.schema.json'
-        }, { failOnEmptyData: false });
+        }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
 
         expect(JSON.stringify(response.errors)).toMatchSnapshot("schema-not-found-invalid-schema-name-filename");
     });
@@ -95,7 +98,7 @@ test.describe("schemaContent query", async () => {
     test('handles invalid schema file name version gracefully', async ({ gql }) => {
         const response = await gql.schemaContentFromFilename({
             schemaFilename: 'base.999.schema.json'
-        }, { failOnEmptyData: false });
+        }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
 
         expect(JSON.stringify(response.errors)).toMatchSnapshot("schema-not-found-invalid-schema-version-filename");
     });

--- a/test/playwright/tests/schemaLoaderInfo.spec.ts
+++ b/test/playwright/tests/schemaLoaderInfo.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@fixtures/gql';
+const environmentName = process.env.ENV || 'local';
 
 test.describe("schemaLoaderInfo query", async () => {
-    test(`matches the expected snapshot for enviromnent: ${process.env.ENV}`, async ({ gql }, testInfo) => {
+    test(`matches the expected snapshot for enviromnent: ${environmentName}`, async ({ gql }, testInfo) => {
       const response = await gql.schemaLoaderInfo()
       expect(JSON.stringify(response.schemaLoaderInfo)).toMatchSnapshot("schemaLoaderInfo.json");
     });

--- a/test/playwright/types/matchers.d.ts
+++ b/test/playwright/types/matchers.d.ts
@@ -1,0 +1,11 @@
+import { expect } from '@playwright/test';
+
+declare global {
+    namespace PlaywrightTest {
+        interface Matchers<R> {
+            toBeRecentInSeconds(threshold?: number): R;
+        }
+    }
+}
+
+export {}; 


### PR DESCRIPTION
Adding tests for getSubmissionDetails
* adding ReportHelper for creating reports to be used for submission details
* adding assertions for validating reports
* adding validation functions
* small updates to other tests for local runs