### PR TITLE
PHDO-592 - Resolve upsertReport null field issues

### DIFF
--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/models/dao/StageInfoDao.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/models/dao/StageInfoDao.kt
@@ -1,6 +1,5 @@
 package gov.cdc.ocio.database.models.dao
 
-import com.google.gson.annotations.SerializedName
 import gov.cdc.ocio.database.dynamo.ReportConverterProvider
 import gov.cdc.ocio.types.model.Issue
 import gov.cdc.ocio.types.model.Status
@@ -39,12 +38,9 @@ data class StageInfoDao(
     @JsonProperty("issues")
     var issues: List<Issue>? = null,
 
-    @SerializedName("start_processing_time")
-    @JsonProperty("start_processing_time")
     @JsonDeserialize(using = EpochToInstantConverter::class)
     var startProcessingTime:  Instant? = null,
-    @SerializedName("end_processing_time")
-    @JsonProperty("end_processing_time")
+
     @JsonDeserialize(using = EpochToInstantConverter::class)
     var endProcessingTime:  Instant? = null
 )

--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
@@ -138,4 +138,10 @@ class CollectionDataFetcher(
     override val collectionNameForQuery = delegate.collectionNameForQuery
 
     override val collectionElementForQuery = delegate.collectionElementForQuery
+
+    override val openBracketChar = delegate.openBracketChar
+
+    override val closeBracketChar = delegate.closeBracketChar
+
+    override val timeConversionForQuery = delegate.timeConversionForQuery
 }

--- a/libs/commons-types/src/main/kotlin/gov/cdc/ocio/types/extensions/MutableMapExtensions.kt
+++ b/libs/commons-types/src/main/kotlin/gov/cdc/ocio/types/extensions/MutableMapExtensions.kt
@@ -1,0 +1,17 @@
+package gov.cdc.ocio.types.extensions
+
+/**
+ * Renames a key in the mutable map. If the old key exists and does not
+ * equal the new key, the associated value is moved to the new key.
+ *
+ * @param oldKey The key to be renamed.
+ * @param newKey The new key to be created.
+ */
+fun <K, V> MutableMap<K, V>.renameKey(oldKey: K, newKey: K) {
+    if (oldKey != newKey && this.containsKey(oldKey)) {
+        val value = this.remove(oldKey)
+        if (value != null || this.containsKey(oldKey)) {
+            this[newKey] = value!!
+        }
+    }
+}

--- a/libs/commons-types/src/main/kotlin/gov/cdc/ocio/types/model/StageInfo.kt
+++ b/libs/commons-types/src/main/kotlin/gov/cdc/ocio/types/model/StageInfo.kt
@@ -1,7 +1,5 @@
 package gov.cdc.ocio.types.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.google.gson.annotations.SerializedName
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
 import java.time.Instant
 
@@ -30,11 +28,7 @@ class StageInfo {
 
     var issues: List<Issue>? = null
 
-    @SerializedName("start_processing_time")
-    @JsonProperty("start_processing_time")
     var startProcessingTime: Instant? = null
 
-    @SerializedName("end_processing_time")
-    @JsonProperty("end_processing_time")
     var endProcessingTime: Instant? = null
 }

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
@@ -185,7 +185,7 @@ class ReportMutationService: KoinComponent {
             if (validationResult.status) {
                 // The report input comes in from graphql as snake case, but all the models are set up for camel case.
                 val camelCaseKeyMap = mapKeysToCamelCase(input).toMutableMap()
-                // Rename known Report keys that don't quiet match in case.
+                // Rename known Report keys that don't quite match in case.
                 camelCaseKeyMap.renameKey(oldKey = "dexIngestDatetime", newKey = "dexIngestDateTime")
                 val reportJson = gson.toJson(camelCaseKeyMap)
                 val report = gson.fromJson(reportJson, Report::class.java)

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
@@ -24,6 +24,7 @@ import gov.cdc.ocio.reportschemavalidator.utils.DefaultJsonUtils
 import gov.cdc.ocio.reportschemavalidator.validators.JsonSchemaValidator
 import gov.cdc.ocio.messagesystem.MessageSystem
 import gov.cdc.ocio.messagesystem.MessageProcessorConfig
+import gov.cdc.ocio.types.extensions.renameKey
 import io.ktor.server.application.*
 import mu.KLogger
 import mu.KotlinLogging
@@ -183,7 +184,9 @@ class ReportMutationService: KoinComponent {
             // if status is successful, will persist report to Reports container, otherwise to dlq container
             if (validationResult.status) {
                 // The report input comes in from graphql as snake case, but all the models are set up for camel case.
-                val camelCaseKeyMap = mapKeysToCamelCase(input)
+                val camelCaseKeyMap = mapKeysToCamelCase(input).toMutableMap()
+                // Rename known Report keys that don't quiet match in case.
+                camelCaseKeyMap.renameKey(oldKey = "dexIngestDatetime", newKey = "dexIngestDateTime")
                 val reportJson = gson.toJson(camelCaseKeyMap)
                 val report = gson.fromJson(reportJson, Report::class.java)
                 return ValidatedReportResult(

--- a/pstatus-graphql-ktor/src/test/kotlin/gov/cdc/ocio/processingstatusapi/loaders/ReportCountsLoaderTest.kt
+++ b/pstatus-graphql-ktor/src/test/kotlin/gov/cdc/ocio/processingstatusapi/loaders/ReportCountsLoaderTest.kt
@@ -1,10 +1,10 @@
 package gov.cdc.ocio.processingstatusapi.loaders
 
 import data.UploadsStatusDataGenerator
-import gov.cdc.ocio.database.cosmos.CosmosCollection
 import gov.cdc.ocio.database.cosmos.CosmosRepository
 import gov.cdc.ocio.processingstatusapi.models.ReportCounts
 import gov.cdc.ocio.database.models.dao.ReportDao
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
 import gov.cdc.ocio.processingstatusapi.models.reports.StageCounts
 import io.mockk.every
 import io.mockk.mockk
@@ -23,7 +23,7 @@ import kotlin.test.assertNotNull
 class ReportCountsLoaderTest {
 
     private val mockCosmosRepository: CosmosRepository = mockk()
-    private val mockReportsCollection: CosmosCollection = mockk()
+    private val mockReportsCollection: CollectionDataFetcher = mockk()
     private val mockReportCountsLoader: ReportCountsLoader = mockk()
 
     private val testModule = module {

--- a/pstatus-graphql-ktor/src/test/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatusLoaderTest.kt
+++ b/pstatus-graphql-ktor/src/test/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatusLoaderTest.kt
@@ -1,9 +1,9 @@
 package gov.cdc.ocio.processingstatusapi.loaders
 
 import data.UploadsStatusDataGenerator
-import gov.cdc.ocio.database.cosmos.CosmosCollection
 import gov.cdc.ocio.database.cosmos.CosmosRepository
 import gov.cdc.ocio.database.models.dao.ReportDao
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
 import gov.cdc.ocio.processingstatusapi.exceptions.BadRequestException
 import gov.cdc.ocio.processingstatusapi.models.query.UploadCounts
 import io.mockk.*
@@ -22,7 +22,7 @@ import kotlin.test.assertFailsWith
 class UploadStatusLoaderTest : KoinTest {
 
     private val mockCosmosRepository: CosmosRepository = mockk()
-    private val mockReportsCollection: CosmosCollection = mockk()
+    private val mockReportsCollection: CollectionDataFetcher = mockk()
     private val uploadStatusLoader: UploadStatusLoader = mockk()
 
     private val testModule = module {

--- a/test/playwright/fixtures/reportHelper.ts
+++ b/test/playwright/fixtures/reportHelper.ts
@@ -62,10 +62,10 @@ export class ReportHelper {
             { response: 'senderId', report: 'sender_id' },
             { response: 'dataProducerId', report: 'data_producer_id' },
             { response: 'contentType', report: 'content_type' },
-            { response: 'dexIngestDateTime', report: 'dex_ingest_date_time',
-                transform: (value: string) => null  // does not populate in response
-             },
-            { response: 'messageMetadata.messageUUID', report: 'message_metadata.message_uuid', 
+            { response: 'dexIngestDateTime', report: 'dex_ingest_datetime',
+                transform: (value: string) => new Date(value).toISOString()
+            },
+            { response: 'messageMetadata.messageUUID', report: 'message_metadata.message_uuid',
                 transform: (value: string) => null  // does not populate in response
             },
             { response: 'messageMetadata.messageHash', report: 'message_metadata.message_hash', 
@@ -83,12 +83,12 @@ export class ReportHelper {
             { response: 'stageInfo.status', report: 'stage_info.status' },
             { response: 'stageInfo.version', report: 'stage_info.version' },
             //{ response: 'stageInfo.issues', report: 'stage_info.issues' },
-            { response: 'stageInfo.startProcessingTime', report: 'stage_info.start_processing_time', 
-                transform: (value: string) => null  // does not populate in response
+            { response: 'stageInfo.startProcessingTime', report: 'stage_info.start_processing_time',
+                transform: (value: string) => new Date(value).toISOString()
             },
-            { response: 'stageInfo.endProcessingTime', report: 'stage_info.end_processing_time', 
-                transform: (value: string) => null  // does not populate in response
-             },
+            { response: 'stageInfo.endProcessingTime', report: 'stage_info.end_processing_time',
+                transform: (value: string) => new Date(value).toISOString()
+            },
             { response: 'content.contentSchemaName', report: 'content.content_schema_name' },
             { response: 'content.contentSchemaVersion', report: 'content.content_schema_version' },
             { response: 'content.status', report: 'content.status' },


### PR DESCRIPTION
### Summary of changes
- Added a key remap for when converting snake to camel case a failure in matching the dex ingest date/time when using the GraphQL upsertReport.
- Made the name of the start and end processing times in stage info consistent in the data access model and graphql models. The effect of this change was to fix an issue with the start and end processing times being null when using the GraphQL upsertReport.

### Test steps
- Stop and delete the old `pstatus-graphql` and `pstatus-report-sink` container images in your docker desktop.
- Grab the **latest** `pstatus-graphql` and `pstatus-report-sink` container images from quay.
- Restart the docker compose to pull the new container images.
- Create a report using `upsertReport` in GraphQL and observe that when retrieving the report the `dexIngestDateTime` and `stageInfo.startProcessingTime` and `stageInfo.endProcessingTime` fields are populated.
- Create reports using the Python load testing script, retrieve the reports from GraphQL `getReports`, and observe that the `dexIngestDateTime` and `stageInfo.startProcessingTime` and `stageInfo.endProcessingTime` fields are populated.