### PR TITLE
Phdo 687/mvel syntax checker

### DIFF
--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/persistence/CollectionDataFetcher.kt
@@ -11,7 +11,7 @@ import kotlin.time.measureTimedValue
  * @constructor Creates an instance of CollectionDataFetcher with a delegate Collection.
  * @param delegate The underlying collection implementation that this class wraps.
  */
-class CollectionDataFetcher(
+open class CollectionDataFetcher(
     private val delegate: Collection
 ) : Collection {
 

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelExpressionCleaner.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelExpressionCleaner.kt
@@ -5,17 +5,18 @@ package gov.cdc.ocio.processingstatusnotifications.rulesEngine
  * Its primary purpose is to remove clauses containing "content." and reconstruct the expression
  * appropriately, while respecting the correct usage of logical operators and parentheses.
  */
+import java.util.regex.Pattern
+
 object MvelExpressionCleaner {
 
-    // Helper to check if a token is a boolean operator
     private fun isOperator(token: String) = token == "&&" || token == "||"
 
     /**
      * Tokenizes an MVEL expression, respecting parentheses and top-level logical operators.
      * Tokens can be clauses, operators (&&, ||), or parenthesized sub-expressions.
      *
-     * @param expr The logical expression to tokenize as a string.
-     * @return A list of string tokens derived from the input expression.
+     * @param expr String
+     * @return List<String>
      */
     private fun tokenize(expr: String): List<String> {
         val tokens = mutableListOf<String>()
@@ -81,16 +82,36 @@ object MvelExpressionCleaner {
     }
 
     /**
-     * Recursively strips clauses containing "content." from a list of tokens.
+     * Checks if a clause string contains the specified field name using dot or bracket notation.
+     * Examples: "fieldName.property", "fieldName['property']", "fieldName[0]"
+     *
+     * @param clause String
+     * @param fieldName String
+     * @return Boolean
+     */
+    private fun doesClauseContainField(
+        clause: String,
+        fieldName: String
+    ): Boolean {
+        val pattern = Pattern.compile(
+            "\\b$fieldName\\s*\\.\\s*|\\b$fieldName\\s*\\[", // Matches "fieldName." or "fieldName ["
+            Pattern.CASE_INSENSITIVE
+        )
+        return pattern.matcher(clause).find()
+    }
+
+    /**
+     * Recursively strips clauses containing the specified field name from a list of tokens.
      * It rebuilds the expression with correct operator placement.
      *
-     * @param tokens A list of token strings representing parts of an expression.
-     *               Tokens may represent clauses, operators, or parenthesized groups.
-     * @return A reconstructed string expression with unwanted parts removed,
-     *         redundant operators cleaned up, and valid clauses retained. If all tokens are removed,
-     *         returns an empty string.
+     * @param tokens List<String>
+     * @param fieldNameToRemove String
+     * @return String
      */
-    private fun stripContentPartsAndReconstruct(tokens: List<String>): String {
+    private fun stripContentPartsAndReconstruct(
+        tokens: List<String>,
+        fieldNameToRemove: String
+    ): String {
         if (tokens.isEmpty()) {
             return ""
         }
@@ -103,15 +124,16 @@ object MvelExpressionCleaner {
                 // If it's a parenthesized group, recurse and add the cleaned inner part
                 token.startsWith("(") && token.endsWith(")") -> {
                     val inner = token.substring(1, token.length - 1)
-                    val cleanedInner = removeContentClauses(inner).trim()
+                    // Recursive call needs to pass the field name
+                    val cleanedInner = removeClauses(inner, fieldNameToRemove).trim()
                     if (cleanedInner.isNotBlank()) {
                         // If inner becomes empty, remove the whole parenthesis.
                         // If it becomes "true", keep "(true)" as it's valid MVEL.
                         filteredTokens.add("($cleanedInner)")
                     }
                 }
-                // If it's a clause containing "content.", skip it
-                token.contains("content.", ignoreCase = true) -> {
+                // If it's a clause containing the specified field, skip it
+                doesClauseContainField(token, fieldNameToRemove) -> {
                     // Do nothing, effectively removing this token
                 }
                 // If it's an operator, add it. Operators will be cleaned up in reconstruction.
@@ -165,22 +187,24 @@ object MvelExpressionCleaner {
     }
 
     /**
-     * Removes clauses containing "content." from the given MVEL expression and reconstructs the cleaned expression.
-     * If the resulting expression becomes empty and originally contained "content." clauses,
-     * the function defaults to returning "true".
+     * Main function to remove clauses containing the specified field name from an MVEL expression.
      *
-     * @param expression The MVEL expression as a string, which may contain clauses, logical operators, and parentheses.
-     * @return The cleaned expression string with all "content." clauses removed, or "true" if the resulting expression
-     *         is empty and originally contained "content.".
+     * @param expression The MVEL expression string.
+     * @param fieldNameToRemove The name of the field to look for (e.g., "content", "data").
+     * Defaults to "content".
+     * @return The modified expression string with clauses containing the field removed.
      */
-    fun removeContentClauses(expression: String): String {
+    fun removeClauses(
+        expression: String,
+        fieldNameToRemove: String = "content"
+    ): String {
         val tokens = tokenize(expression)
-        val cleanedExpression = stripContentPartsAndReconstruct(tokens)
+        val cleanedExpression = stripContentPartsAndReconstruct(tokens, fieldNameToRemove)
 
-        // If the expression becomes empty after cleaning and it originally contained "content.",
-        // you might want to default it to "true" or "" based on your application's logic.
-        // Returning "true" is common if the expression is for a conditional check.
-        return if (cleanedExpression.isBlank() && expression.contains("content.", ignoreCase = true)) {
+        // If the expression becomes empty after cleaning and it originally contained the field,
+        // default it to "true" (common for boolean expressions) or "" based on your logic.
+        // Use the general fieldNameToRemove to check for original presence.
+        return if (cleanedExpression.isBlank() && doesClauseContainField(expression, fieldNameToRemove)) {
             "true"
         } else {
             cleanedExpression

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelExpressionCleaner.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelExpressionCleaner.kt
@@ -1,0 +1,189 @@
+package gov.cdc.ocio.processingstatusnotifications.rulesEngine
+
+/**
+ * An object for parsing, tokenizing, and cleaning MVEL expressions.
+ * Its primary purpose is to remove clauses containing "content." and reconstruct the expression
+ * appropriately, while respecting the correct usage of logical operators and parentheses.
+ */
+object MvelExpressionCleaner {
+
+    // Helper to check if a token is a boolean operator
+    private fun isOperator(token: String) = token == "&&" || token == "||"
+
+    /**
+     * Tokenizes an MVEL expression, respecting parentheses and top-level logical operators.
+     * Tokens can be clauses, operators (&&, ||), or parenthesized sub-expressions.
+     *
+     * @param expr The logical expression to tokenize as a string.
+     * @return A list of string tokens derived from the input expression.
+     */
+    private fun tokenize(expr: String): List<String> {
+        val tokens = mutableListOf<String>()
+        var i = 0
+        var parens = 0 // Tracks nesting level of parentheses
+        var current = StringBuilder()
+
+        while (i < expr.length) {
+            val c = expr[i]
+
+            when {
+                // Handle opening parenthesis
+                c == '(' -> {
+                    if (parens == 0 && current.isNotEmpty()) { // If top-level content before '('
+                        tokens.add(current.toString().trim())
+                        current = StringBuilder()
+                    }
+                    current.append(c)
+                    parens++
+                }
+                // Handle closing parenthesis
+                c == ')' -> {
+                    current.append(c)
+                    parens--
+                    if (parens == 0) { // End of top-level parenthesized group
+                        tokens.add(current.toString().trim())
+                        current = StringBuilder()
+                    }
+                }
+                // Handle top-level '&&' operator
+                parens == 0 && expr.startsWith("&&", i) -> {
+                    if (current.isNotEmpty()) {
+                        tokens.add(current.toString().trim())
+                        current = StringBuilder()
+                    }
+                    tokens.add("&&")
+                    i++ // Consume the second '&'
+                }
+                // Handle top-level '||' operator
+                parens == 0 && expr.startsWith("||", i) -> {
+                    if (current.isNotEmpty()) {
+                        tokens.add(current.toString().trim())
+                        current = StringBuilder()
+                    }
+                    tokens.add("||")
+                    i++ // Consume the second '|'
+                }
+                // Append character to current token
+                else -> {
+                    current.append(c)
+                }
+            }
+            i++ // Move to the next character
+        }
+
+        // Add any remaining part of the expression as a token
+        if (current.isNotEmpty()) {
+            tokens.add(current.toString().trim())
+        }
+
+        // Filter out any blank tokens that might result from trimming/whitespace
+        return tokens.filter { it.isNotBlank() }
+    }
+
+    /**
+     * Recursively strips clauses containing "content." from a list of tokens.
+     * It rebuilds the expression with correct operator placement.
+     *
+     * @param tokens A list of token strings representing parts of an expression.
+     *               Tokens may represent clauses, operators, or parenthesized groups.
+     * @return A reconstructed string expression with unwanted parts removed,
+     *         redundant operators cleaned up, and valid clauses retained. If all tokens are removed,
+     *         returns an empty string.
+     */
+    private fun stripContentPartsAndReconstruct(tokens: List<String>): String {
+        if (tokens.isEmpty()) {
+            return ""
+        }
+
+        val filteredTokens = mutableListOf<String>()
+        for (i in tokens.indices) {
+            val token = tokens[i]
+
+            when {
+                // If it's a parenthesized group, recurse and add the cleaned inner part
+                token.startsWith("(") && token.endsWith(")") -> {
+                    val inner = token.substring(1, token.length - 1)
+                    val cleanedInner = removeContentClauses(inner).trim()
+                    if (cleanedInner.isNotBlank()) {
+                        // If inner becomes empty, remove the whole parenthesis.
+                        // If it becomes "true", keep "(true)" as it's valid MVEL.
+                        filteredTokens.add("($cleanedInner)")
+                    }
+                }
+                // If it's a clause containing "content.", skip it
+                token.contains("content.", ignoreCase = true) -> {
+                    // Do nothing, effectively removing this token
+                }
+                // If it's an operator, add it. Operators will be cleaned up in reconstruction.
+                isOperator(token) -> {
+                    filteredTokens.add(token)
+                }
+                // Otherwise, it's a valid clause to keep
+                else -> {
+                    filteredTokens.add(token)
+                }
+            }
+        }
+
+        // --- Reconstruction Phase ---
+        val finalExpressionParts = mutableListOf<String>()
+        var lastWasClause = false
+
+        for (token in filteredTokens) {
+            if (isOperator(token)) {
+                if (lastWasClause) { // Add operator only if there's a clause before it
+                    finalExpressionParts.add(token)
+                    lastWasClause = false
+                }
+            } else {
+                finalExpressionParts.add(token)
+                lastWasClause = true
+            }
+        }
+
+        // Join parts and perform final cleanup of operators and parentheses
+        var result = finalExpressionParts.joinToString(" ").trim()
+
+        // Remove redundant operators (e.g., "A && && B" -> "A && B")
+        result = result.replace("\\s*&&\\s*&&\\s*".toRegex(), " && ")
+            .replace("\\s*\\|\\|\\s*\\|\\|\\s*".toRegex(), " || ")
+
+        // Remove leading/trailing operators if the expression starts/ends with one
+        if (result.startsWith("&&") || result.startsWith("||")) {
+            val firstNonOpIndex = result.indexOfFirst { !it.isWhitespace() && it != '&' && it != '|' }
+            result = if (firstNonOpIndex != -1) result.substring(firstNonOpIndex).trim() else ""
+        }
+        if (result.endsWith("&&") || result.endsWith("||")) {
+            val lastNonOpIndex = result.indexOfLast { !it.isWhitespace() && it != '&' && it != '|' }
+            result = if (lastNonOpIndex != -1) result.substring(0, lastNonOpIndex + 1).trim() else ""
+        }
+
+        // Remove empty parentheses that might result from content removal like "A && ()"
+        result = result.replace("\\(\\s*\\)".toRegex(), "").trim()
+
+        return result
+    }
+
+    /**
+     * Removes clauses containing "content." from the given MVEL expression and reconstructs the cleaned expression.
+     * If the resulting expression becomes empty and originally contained "content." clauses,
+     * the function defaults to returning "true".
+     *
+     * @param expression The MVEL expression as a string, which may contain clauses, logical operators, and parentheses.
+     * @return The cleaned expression string with all "content." clauses removed, or "true" if the resulting expression
+     *         is empty and originally contained "content.".
+     */
+    fun removeContentClauses(expression: String): String {
+        val tokens = tokenize(expression)
+        val cleanedExpression = stripContentPartsAndReconstruct(tokens)
+
+        // If the expression becomes empty after cleaning and it originally contained "content.",
+        // you might want to default it to "true" or "" based on your application's logic.
+        // Returning "true" is common if the expression is for a conditional check.
+        return if (cleanedExpression.isBlank() && expression.contains("content.", ignoreCase = true)) {
+            "true"
+        } else {
+            cleanedExpression
+        }
+    }
+}

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidationResult.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidationResult.kt
@@ -1,0 +1,13 @@
+package gov.cdc.ocio.processingstatusnotifications.rulesEngine
+
+/**
+ * Represents the result of an MVEL expression validation operation.
+ *
+ * @property isValid Indicates whether the MVEL expression is valid.
+ * @property errorMessage Provides details about the validation error if the expression is not valid, or null if there
+ * are no errors.
+ */
+data class MvelValidationResult(
+    val isValid: Boolean,
+    val errorMessage: String? = null
+)

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
@@ -53,7 +53,7 @@ class MvelValidator(
     fun validate(expression: String): MvelValidationResult {
         return try {
             val parserContext = createParserContext()
-            val cleanedExpression = MvelExpressionCleaner.removeContentClauses(expression)
+            val cleanedExpression = MvelExpressionCleaner.removeClauses(expression)
             logger.info("Cleaned expression: $cleanedExpression")
             MVEL.analysisCompile(cleanedExpression, parserContext)
             MvelValidationResult(true)

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
@@ -1,0 +1,68 @@
+package gov.cdc.ocio.processingstatusnotifications.rulesEngine
+
+import gov.cdc.ocio.types.model.MessageMetadata
+import gov.cdc.ocio.types.model.StageInfo
+import gov.cdc.ocio.types.model.Status
+import org.mvel2.MVEL
+import org.mvel2.ParserContext
+
+
+/**
+ * A utility class for validating MVEL expressions in a strongly-typed context. This class enables safe evaluation of
+ * MVEL syntax by ensuring that the expressions conform to the expected structure and use of variables.
+ *
+ * @property contextVars A map defining the context variables available in the expression, where the key represents
+ * the variable name and the value is its corresponding class type.
+ *
+ * The default context includes:
+ * - stageInfo: Represents metadata related to a processing stage using the StageInfo class.
+ * - messageMetadata: Represents metadata of a message using the MessageMetadata class.
+ * - Status: A reference to the Status enum indicating processing status.
+ *
+ * @constructor Initializes the MvelValidator with a map of context variables. If no context is provided, the default
+ * context is used.
+ */
+class MvelValidator(
+    private val contextVars: Map<String, Class<*>> = defaultContext
+) {
+
+    /**
+     * Creates a strongly-typed parser context for validating MVEL expressions. The parser context is initialized
+     * with strong typing enabled and populated with the defined context variables from the containing class.
+     *
+     * @return A configured instance of ParserContext with strong typing and registered context variables.
+     */
+    private fun createParserContext(): ParserContext {
+        val context = ParserContext()
+        context.isStrongTyping = true
+        contextVars.forEach { (name, clazz) ->
+            context.addInput(name, clazz)
+        }
+        return context
+    }
+
+    /**
+     * Validates the given MVEL expression for syntax and context correctness.
+     *
+     * @param expression The MVEL expression to be validated as a string.
+     * @return An instance of MvelValidationResult indicating whether the validation was successful
+     *         and providing an error message if applicable.
+     */
+    fun validate(expression: String): MvelValidationResult {
+        return try {
+            val parserContext = createParserContext()
+            MVEL.analysisCompile(expression, parserContext)
+            MvelValidationResult(true)
+        } catch (ex: Exception) {
+            MvelValidationResult(false, ex.message)
+        }
+    }
+
+    companion object {
+        val defaultContext = mapOf(
+            "stageInfo" to StageInfo::class.java,
+            "messageMetadata" to MessageMetadata::class.java,
+            "Status" to Status::class.java,
+        )
+    }
+}

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/MvelValidator.kt
@@ -3,9 +3,9 @@ package gov.cdc.ocio.processingstatusnotifications.rulesEngine
 import gov.cdc.ocio.types.model.MessageMetadata
 import gov.cdc.ocio.types.model.StageInfo
 import gov.cdc.ocio.types.model.Status
+import mu.KotlinLogging
 import org.mvel2.MVEL
 import org.mvel2.ParserContext
-
 
 /**
  * A utility class for validating MVEL expressions in a strongly-typed context. This class enables safe evaluation of
@@ -25,6 +25,8 @@ import org.mvel2.ParserContext
 class MvelValidator(
     private val contextVars: Map<String, Class<*>> = defaultContext
 ) {
+
+    private val logger = KotlinLogging.logger {}
 
     /**
      * Creates a strongly-typed parser context for validating MVEL expressions. The parser context is initialized
@@ -51,7 +53,9 @@ class MvelValidator(
     fun validate(expression: String): MvelValidationResult {
         return try {
             val parserContext = createParserContext()
-            MVEL.analysisCompile(expression, parserContext)
+            val cleanedExpression = MvelExpressionCleaner.removeContentClauses(expression)
+            logger.info("Cleaned expression: $cleanedExpression")
+            MVEL.analysisCompile(cleanedExpression, parserContext)
             MvelValidationResult(true)
         } catch (ex: Exception) {
             MvelValidationResult(false, ex.message)

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/subscription/SubscriptionManager.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/subscription/SubscriptionManager.kt
@@ -45,7 +45,7 @@ class SubscriptionManager : KoinComponent {
         // Syntax and type checking for the MVEL expression
         val validator = MvelValidator()
         val result = validator.validate(mvelCondition)
-        if (!result.isValid) throw IllegalArgumentException("Invalid MVEL expression: ${result.errorMessage}")
+        require(result.isValid) { "Invalid MVEL expression: ${result.errorMessage}" }
 
         val existingSubscriptionId = cachedSubscriptionLoader.findSubscriptionId(subscription)
         return if (existingSubscriptionId != null)

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/subscription/SubscriptionManager.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/subscription/SubscriptionManager.kt
@@ -1,9 +1,9 @@
 package gov.cdc.ocio.processingstatusnotifications.subscription
 
 import gov.cdc.ocio.processingstatusnotifications.exception.*
-import gov.cdc.ocio.types.model.Notification
 import gov.cdc.ocio.processingstatusnotifications.model.Subscription
-import gov.cdc.ocio.types.model.SubscriptionRule
+import gov.cdc.ocio.processingstatusnotifications.rulesEngine.MvelValidator
+import gov.cdc.ocio.types.model.*
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.*
@@ -41,6 +41,11 @@ class SubscriptionManager : KoinComponent {
             SubscriptionRule(dataStreamId, dataStreamRoute, jurisdiction, ruleDescription, mvelCondition),
             notification
         )
+
+        // Syntax and type checking for the MVEL expression
+        val validator = MvelValidator()
+        val result = validator.validate(mvelCondition)
+        if (!result.isValid) throw IllegalArgumentException("Invalid MVEL expression: ${result.errorMessage}")
 
         val existingSubscriptionId = cachedSubscriptionLoader.findSubscriptionId(subscription)
         return if (existingSubscriptionId != null)

--- a/pstatus-notifications-rules-engine-ktor/src/test/kotlin/cache/MockCollectionDataFetcher.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/test/kotlin/cache/MockCollectionDataFetcher.kt
@@ -1,0 +1,5 @@
+package cache
+
+import gov.cdc.ocio.database.persistence.CollectionDataFetcher
+
+class MockCollectionDataFetcher: CollectionDataFetcher(MockCollection())

--- a/pstatus-notifications-rules-engine-ktor/src/test/kotlin/cache/SubscriptionManagerTest.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/test/kotlin/cache/SubscriptionManagerTest.kt
@@ -33,7 +33,7 @@ class SubscriptionManagerTest {
                 }
             )
         }
-        every { processingStatusRepoMock.notificationSubscriptionsCollection } returns MockCollection()
+        every { processingStatusRepoMock.notificationSubscriptionsCollection } returns MockCollectionDataFetcher()
         every { processingStatusRepoMock.healthCheckSystem } returns MockHealthCheckSystem("Database", "Mock DB")
         subscriptionManager = SubscriptionManager()
     }


### PR DESCRIPTION
### Summary of changes
- Added a strict validation of the MVEL condition passed in to the rules engine when subscribing. This allows for feedback of a failed rule at the time of subscribing rather than at runtime.
- Fixed `pstatus-notifications-rules-engine` unit tests

### Example MVEL condition tests:
#### Test 1: Pass
```graphql
mutation SubscribeWebhook {
    subscribeWebhook(
        dataStreamId: "dex-testing"
        dataStreamRoute: "test-event4"
        jurisdiction: null
        ruleDescription: "Send email when upload succeeds"
        mvelCondition: "stageInfo.service == 'UPLOAD API' && stageInfo.action == 'upload-completed' && stageInfo.status == Status.SUCCESS"
        webhookUrl: "https://webhook.site/6e5508da-1e87-4f4f-8eda-48c2acd66624"
    ) {
        subscriptionId
    }
}
```
Returns:
```json
{
    "data": {
        "subscribeWebhook": {
            "subscriptionId": "83d93032-2ae4-4929-ba83-d63d75af0a2b"
        }
    }
}
```
#### Test 2: Fail
```graphql
mutation SubscribeWebhook {
    subscribeWebhook(
        dataStreamId: "dex-testing"
        dataStreamRoute: "test-event4"
        jurisdiction: null
        ruleDescription: "Send email when upload succeeds"
        mvelCondition: "stageInfo.service1 == ''"
        webhookUrl: "https://webhook.site/6e5508da-1e87-4f4f-8eda-48c2acd66624"
    ) {
        subscriptionId
    }
}
```
Returns:
```json
{
    "errors": [
        {
            "message": "Invalid MVEL expression: [Error: unqualified type in strict mode for: service1]\n[Near : {... stageInfo.service1 == '' ....}]\n                       ^\n[Line: 1, Column: 11]",
            "locations": [],
            "path": [
                "subscribeWebhook"
            ],
            "extensions": {
                "classification": "BadRequestException"
            }
        }
    ]
}
```