### PR TITLE
PHDO-857 - GraphQL upload stats bug fixes

### DIFF
--- a/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/SqlClauseBuilder.kt
+++ b/libs/commons-database/src/main/kotlin/gov/cdc/ocio/database/utils/SqlClauseBuilder.kt
@@ -44,11 +44,11 @@ object SqlClauseBuilder {
             timeRangeSqlPortion.append("${cPrefix}dexIngestDateTime >= ${timeFunc(dateStartEpochSecs)}")
         } else {
             dateStart?.let {
-                val dateStartEpochSecs = DateUtils.getEpochFromDateString(it)
+                val dateStartEpochSecs = DateUtils.getEpochFromDateString(it) / 1000
                 timeRangeSqlPortion.append("${cPrefix}dexIngestDateTime >= ${timeFunc(dateStartEpochSecs)}")
             }
             dateEnd?.let {
-                val dateEndEpochSecs = DateUtils.getEpochFromDateString(it)
+                val dateEndEpochSecs = DateUtils.getEpochFromDateString(it) / 1000
                 timeRangeSqlPortion.append(" AND ${cPrefix}dexIngestDateTime < ${timeFunc(dateEndEpochSecs)}")
             }
         }

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
@@ -76,7 +76,7 @@ class UploadStatsLoader: KoinComponent {
 
         val duplicateFilenameCountQuery = (
                 "select * from "
-                        + "(select ${cPrefix}content.metadata.received_filename, count(1) as totalCount "
+                        + "(select ${cPrefix}content.metadata.received_filename as filename, count(1) as totalCount "
                         + "from $cName $cVar "
                         + "where ${cPrefix}dataStreamId = '$dataStreamId' and ${cPrefix}dataStreamRoute = '$dataStreamRoute' and "
                         + "${cPrefix}stageInfo.service = 'UPLOAD API' and ${cPrefix}stageInfo.${cElFunc("action")} = 'metadata-verify' and "

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/loaders/UploadStatsLoader.kt
@@ -1,10 +1,13 @@
 package gov.cdc.ocio.processingstatusapi.loaders
 
+import gov.cdc.ocio.database.models.StageAction
+import gov.cdc.ocio.database.models.StageService
 import gov.cdc.ocio.database.persistence.ProcessingStatusRepository
 import gov.cdc.ocio.database.utils.SqlClauseBuilder
 import gov.cdc.ocio.processingstatusapi.exceptions.BadRequestException
 import gov.cdc.ocio.processingstatusapi.exceptions.ContentException
 import gov.cdc.ocio.processingstatusapi.models.query.*
+import gov.cdc.ocio.types.model.Status
 import mu.KotlinLogging
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -53,7 +56,7 @@ class UploadStatsLoader: KoinComponent {
                 "select value count(1) "
                         + "from $cName $cVar "
                         + "where ${cPrefix}dataStreamId = '$dataStreamId' and ${cPrefix}dataStreamRoute = '$dataStreamRoute' and "
-                        + "${cPrefix}stageInfo.service = 'UPLOAD API' and ${cPrefix}stageInfo.${cElFunc("action")} = 'upload-status' and "
+                        + "${cPrefix}stageInfo.service = '${StageService.UPLOAD_API}' and ${cPrefix}stageInfo.${cElFunc("action")} = '${StageAction.UPLOAD_STATUS}' and "
                         + timeRangeWhereClause
                 )
 
@@ -61,7 +64,7 @@ class UploadStatsLoader: KoinComponent {
                 "select value count(1) "
                         + "from $cName $cVar "
                         + "where ${cPrefix}dataStreamId = '$dataStreamId' and ${cPrefix}dataStreamRoute = '$dataStreamRoute' and "
-                        + "${cPrefix}stageInfo.service = 'UPLOAD API' and ${cPrefix}stageInfo.${cElFunc("action")} = 'metadata-verify' and "
+                        + "${cPrefix}stageInfo.service = '${StageService.UPLOAD_API}' and ${cPrefix}stageInfo.${cElFunc("action")} = '${StageAction.METADATA_VERIFY}' and "
                         + "ARRAY_LENGTH(${cPrefix}stageInfo.issues) > 0 and $timeRangeWhereClause"
                 )
 
@@ -69,8 +72,8 @@ class UploadStatsLoader: KoinComponent {
                 "select value count(1) "
                         + "from $cName $cVar "
                         + "where ${cPrefix}dataStreamId = '$dataStreamId' and ${cPrefix}dataStreamRoute = '$dataStreamRoute' and "
-                        + "${cPrefix}stageInfo.service = 'UPLOAD API' and ${cPrefix}stageInfo.${cElFunc("action")} = 'upload-completed' and "
-                        + "${cPrefix}stageInfo.status = 'SUCCESS' and "
+                        + "${cPrefix}stageInfo.service = '${StageService.UPLOAD_API}' and ${cPrefix}stageInfo.${cElFunc("action")} = '${StageAction.UPLOAD_COMPLETED}' and "
+                        + "${cPrefix}stageInfo.status = '${Status.SUCCESS}' and "
                         + "$timeRangeWhereClause "
                 )
 
@@ -79,7 +82,7 @@ class UploadStatsLoader: KoinComponent {
                         + "(select ${cPrefix}content.metadata.received_filename as filename, count(1) as totalCount "
                         + "from $cName $cVar "
                         + "where ${cPrefix}dataStreamId = '$dataStreamId' and ${cPrefix}dataStreamRoute = '$dataStreamRoute' and "
-                        + "${cPrefix}stageInfo.service = 'UPLOAD API' and ${cPrefix}stageInfo.${cElFunc("action")} = 'metadata-verify' and "
+                        + "${cPrefix}stageInfo.service = '${StageService.UPLOAD_API}' and ${cPrefix}stageInfo.${cElFunc("action")} = '${StageAction.METADATA_VERIFY}' and "
                         + "$timeRangeWhereClause "
                         + "group by ${cPrefix}content.metadata.received_filename"
                         + ") $cVar where ${cPrefix}totalCount > 1"

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/services/ReportMutationService.kt
@@ -203,7 +203,7 @@ class ReportMutationService: KoinComponent {
             // if status is successful, will persist report to Reports container, otherwise to dlq container
             if (validationResult.status) {
                 // The report input comes in from graphql as snake case, but all the models are set up for camel case.
-                val camelCaseKeyMap = mapKeysToCamelCase(input).toMutableMap()
+                val camelCaseKeyMap = mapKeysToCamelCase(input, ignore = listOf("content")).toMutableMap()
                 // Rename known Report keys that don't quite match in case.
                 camelCaseKeyMap.renameKey(oldKey = "dexIngestDatetime", newKey = "dexIngestDateTime")
                 val reportJson = gson.toJson(camelCaseKeyMap)
@@ -225,28 +225,43 @@ class ReportMutationService: KoinComponent {
     }
 
     /**
-     * Re-map the keys of the provided map from snake case to camel case.
+     * Recursively transforms the keys of a map from snake_case to camelCase.
+     * Keys present in the `ignore` parameter are excluded from the transformation.
      *
-     * @param map Map<String, Any?>?
-     * @return Map<String, Any?>
+     * @param map The input map whose keys are to be converted, or null if no map needs processing.
+     * @param ignore Vararg of keys that should be excluded from the transformation.
+     * @return A new map with keys transformed to camelCase, keeping the original values intact. Nested maps will also
+     * have their keys transformed recursively.
      */
-    private fun mapKeysToCamelCase(map: Map<String, Any?>?): Map<String, Any?> {
-        val newMap = mutableMapOf<String, Any?>()
+    private fun mapKeysToCamelCase(
+        map: Map<String, Any?>?,
+        ignore: List<String>,
+        parentPath: String = ""
+    ): Map<String, Any?> {
+        val sourceMap = map ?: return emptyMap()
+        val ignoredPaths = ignore.toSet()
 
-        if (map != null) {
-            for ((key, value) in map) {
-                val newKey = key.snakeToCamelCase() // Example transformation, adjust as needed
+        val result = mutableMapOf<String, Any?>()
 
-                val newValue = when (value) {
-                    is Map<*, *> -> mapKeysToCamelCase(value as Map<String, Any?>) // Recursively convert nested maps
-                    else -> value
+        for ((key, value) in sourceMap) {
+            val fullPath = if (parentPath.isEmpty()) key else "$parentPath.$key"
+
+            val shouldIgnore = ignoredPaths.any { fullPath == it || fullPath.startsWith("$it.") }
+
+            val newKey = if (shouldIgnore) key else key.snakeToCamelCase()
+
+            val newValue = when (value) {
+                is Map<*, *> -> {
+                    @Suppress("UNCHECKED_CAST")
+                    mapKeysToCamelCase(value as Map<String, Any?>, ignore, parentPath = fullPath)
                 }
-
-                newMap[newKey] = newValue
+                else -> value
             }
+
+            result[newKey] = newValue
         }
 
-        return newMap
+        return result
     }
 
     /**


### PR DESCRIPTION
### Summary of changes
Corrects filename extraction in duplicate filename query and adjusts epoch conversion for date range filtering.

- Modified SQL query in UploadStatsLoader.kt to correctly alias content.metadata.received_filename as filename in the subquery for duplicate filename counting.
- Corrected date to epoch conversion in SqlClauseBuilder.kt by dividing the epoch value from DateUtils.getEpochFromDateString by 1000.