### PR TITLE
PHDO-797 - Notification rules engine stops checking rules if a bad rule is encountered

### DIFF
--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/RuleEngine.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/RuleEngine.kt
@@ -53,7 +53,7 @@ object RuleEngine: KoinComponent {
             runCatching {
                 evaluateSubscription(report, subscription)
             }.onFailure { ex ->
-                logger.error("Failed to evaluate subscription: ${subscription.key} with exception: ${ex.message}", subscription)
+                logger.error("Failed to evaluate subscription: ${subscription.key}", ex)
             }
         }
     }

--- a/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/RuleEngine.kt
+++ b/pstatus-notifications-rules-engine-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusnotifications/rulesEngine/RuleEngine.kt
@@ -49,8 +49,13 @@ object RuleEngine: KoinComponent {
     fun evaluateAllRules(
         report: ReportMessage
     ) {
-        val subscriptions = getSubscriptions()
-        subscriptions.forEach { evaluateSubscription(report, it) }
+        getSubscriptions().forEach { subscription ->
+            runCatching {
+                evaluateSubscription(report, subscription)
+            }.onFailure { ex ->
+                logger.error("Failed to evaluate subscription: ${subscription.key} with exception: ${ex.message}", subscription)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Summary of changes
- Continue running through subscriptions even if one causes an exception

### Test steps
- Create a rule with a bad `content` field evaluation. Now that we have syntax and field validations, the only field not examined is `content`.
- Create an additional valid rule. Verify that the valid rule still runs.