### PR TITLE
PHDO-736 - Workflow fail rework

### DIFF
--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/WorkflowStatus.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/WorkflowStatus.kt
@@ -10,6 +10,7 @@ import java.time.OffsetDateTime
  * Model for the workflow status.
  *
  * @property workflowId String
+ * @property runId String
  * @property taskName String
  * @property description String
  * @property status String
@@ -21,6 +22,9 @@ import java.time.OffsetDateTime
 data class WorkflowStatus(
     @GraphQLDescription("Workflow ID of the scheduled evaluation workflow")
     val workflowId: String,
+
+    @GraphQLDescription("Run ID of the scheduled evaluation workflow")
+    val runId: String,
 
     @GraphQLDescription("Name of the task to run in the workflow")
     val taskName: String,

--- a/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/WorkflowStatus.kt
+++ b/pstatus-graphql-ktor/src/main/kotlin/gov/cdc/ocio/processingstatusapi/models/query/WorkflowStatus.kt
@@ -32,7 +32,10 @@ data class WorkflowStatus(
     val status: String,
 
     @GraphQLDescription("Schedule for the workflow to run its evaluation")
-    val schedule: CronSchedule
+    val schedule: CronSchedule,
+
+    @GraphQLDescription("Detailed information regarding a workflow failure, if any")
+    val workflowFailureInfo: WorkflowFailureInfo? = null
 )
 
 /**
@@ -58,4 +61,30 @@ data class CronSchedule(
 
     @GraphQLDescription("Next evaluation workflow execution date/time based on the schedule")
     val nextExecution: String?
+)
+
+@Serializable
+@GraphQLDescription("Detailed information regarding a workflow failure, if any")
+data class WorkflowFailureInfo(
+
+    @GraphQLDescription("Source of the failure")
+    val source: String,
+
+    @GraphQLDescription("Failure message")
+    val failureMessage: String?,
+
+    @GraphQLDescription("Cause of the failure")
+    val causeMessage: String?,
+
+    @GraphQLDescription("Stack trace of the failure")
+    val stackTrace: String?,
+
+    @GraphQLDescription("Activity name of the failure")
+    val activityName: String?,
+
+    @GraphQLDescription("Retry state of the failure")
+    val retryState: String?,
+
+    @GraphQLDescription("Timeout type of the failure")
+    val timeoutType: String?
 )

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/model/WorkflowStatus.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/model/WorkflowStatus.kt
@@ -1,17 +1,20 @@
 package gov.cdc.ocio.processingnotifications.model
 
+import gov.cdc.ocio.processingnotifications.temporal.WorkflowFailureInfo
+
 
 /**
- * Model for the workflow status.
+ * Represents the status of a workflow, providing details about its context, execution, and potential errors.
  *
  * @property workflowId String
  * @property taskName String
  * @property taskQueue String
  * @property description String
- * @property status String
  * @property workerAttached Boolean?
+ * @property status String
  * @property schedule CronSchedule
  * @property workflowImplClassName String?
+ * @property workflowFailureInfo WorkflowFailureInfo
  * @constructor
  */
 data class WorkflowStatus(
@@ -22,6 +25,6 @@ data class WorkflowStatus(
     val workerAttached: Boolean?,
     val status: String,
     val schedule: CronSchedule,
-    val workflowImplClassName: String?
+    val workflowImplClassName: String?,
+    val workflowFailureInfo: WorkflowFailureInfo?
 )
-

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/model/WorkflowStatus.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/model/WorkflowStatus.kt
@@ -7,6 +7,7 @@ import gov.cdc.ocio.processingnotifications.temporal.WorkflowFailureInfo
  * Represents the status of a workflow, providing details about its context, execution, and potential errors.
  *
  * @property workflowId String
+ * @property runId String
  * @property taskName String
  * @property taskQueue String
  * @property description String
@@ -19,6 +20,7 @@ import gov.cdc.ocio.processingnotifications.temporal.WorkflowFailureInfo
  */
 data class WorkflowStatus(
     val workflowId: String,
+    val runId: String,
     val taskName: String,
     val taskQueue: String,
     val description: String,

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/WorkflowStatusService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/WorkflowStatusService.kt
@@ -12,7 +12,7 @@ class WorkflowStatusService : KoinComponent {
     /**
      * Get and return all the Temporal workflows.
      */
-    fun getAllWorkflows(): List<Map<String, Any>>  {
+    fun getAllWorkflows(): List<Map<String, Any?>>  {
         try {
             return workflowEngine.getAllWorkflows().map {
                 // Only provide a subset of the workflow status to callers as the other data is superfluous.
@@ -21,7 +21,8 @@ class WorkflowStatusService : KoinComponent {
                     "taskName" to it.taskName,
                     "description" to it.description,
                     "status" to it.status,
-                    "schedule" to it.schedule
+                    "schedule" to it.schedule,
+                    "workflowFailureInfo" to it.workflowFailureInfo
                 )
             }
         } catch (e: Exception) {

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/WorkflowStatusService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/WorkflowStatusService.kt
@@ -18,6 +18,7 @@ class WorkflowStatusService : KoinComponent {
                 // Only provide a subset of the workflow status to callers as the other data is superfluous.
                 mapOf(
                     "workflowId" to it.workflowId,
+                    "runId" to it.runId,
                     "taskName" to it.taskName,
                     "description" to it.description,
                     "status" to it.status,

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -314,6 +314,7 @@ class WorkflowEngine(
             )
             WorkflowStatus(
                 executionInfo.execution.workflowId,
+                executionInfo.execution.runId,
                 taskName,
                 taskQueue,
                 description,

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -293,6 +293,7 @@ class WorkflowEngine(
             val workflowImplClassNamePayload = runCatching { executionInfo.memo.getFieldsOrThrow("workflowImplClassName") }
             val workflowImplClassName = workflowImplClassNamePayload.getOrNull()?.data?.toStringUtf8()?.replace("\"", "")
             val workerAttached = if (includeWorkerCheck) workerHasPoller(executionInfo.taskQueue) else null
+            val failureInfo = getWorkflowFailureInfo(service, temporalConfig.namespace, executionInfo.execution)
 
             val cronSchedule = CronSchedule(
                 cron = cronScheduleRaw,
@@ -310,7 +311,8 @@ class WorkflowEngine(
                 workerAttached,
                 executionInfo.status.name,
                 cronSchedule,
-                workflowImplClassName
+                workflowImplClassName,
+                failureInfo
             )
         }
 

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -293,7 +293,7 @@ class WorkflowEngine(
             val workflowImplClassNamePayload = runCatching { executionInfo.memo.getFieldsOrThrow("workflowImplClassName") }
             val workflowImplClassName = workflowImplClassNamePayload.getOrNull()?.data?.toStringUtf8()?.replace("\"", "")
             val workerAttached = if (includeWorkerCheck) workerHasPoller(executionInfo.taskQueue) else null
-            val failureInfo = getWorkflowFailureInfo(service, temporalConfig.namespace, executionInfo.execution)
+            val failureInfo = executionInfo.execution.getWorkflowFailureInfo(service, temporalConfig.namespace)
 
             val cronSchedule = CronSchedule(
                 cron = cronScheduleRaw,

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowEngine.kt
@@ -11,12 +11,8 @@ import io.grpc.StatusRuntimeException
 import io.temporal.api.enums.v1.TaskQueueKind
 import io.temporal.api.enums.v1.WorkflowExecutionStatus
 import io.temporal.api.workflow.v1.WorkflowExecutionInfo
-import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest
-import io.temporal.api.workflowservice.v1.ListWorkflowExecutionsRequest
-import io.temporal.api.workflowservice.v1.DescribeTaskQueueRequest
 import io.temporal.api.taskqueue.v1.TaskQueue
 import io.temporal.api.enums.v1.TaskQueueType
-import io.temporal.api.workflowservice.v1.DescribeTaskQueueResponse
 import io.temporal.client.WorkflowClient
 import io.temporal.client.WorkflowClientOptions
 import io.temporal.client.WorkflowOptions
@@ -40,6 +36,7 @@ import gov.cdc.ocio.processingnotifications.workflow.digestcounts.UploadDigestCo
 import gov.cdc.ocio.processingnotifications.workflow.digestcounts.UploadDigestCountsNotificationWorkflowImpl
 import gov.cdc.ocio.processingnotifications.workflow.toperrors.TopErrorsNotificationWorkflowImpl
 import gov.cdc.ocio.processingnotifications.workflow.toperrors.TopErrorsNotificationActivitiesImpl
+import io.temporal.api.workflowservice.v1.*
 import io.temporal.client.WorkflowNotFoundException
 import io.temporal.common.converter.DefaultDataConverter
 import io.temporal.common.converter.JacksonJsonPayloadConverter
@@ -293,7 +290,19 @@ class WorkflowEngine(
             val workflowImplClassNamePayload = runCatching { executionInfo.memo.getFieldsOrThrow("workflowImplClassName") }
             val workflowImplClassName = workflowImplClassNamePayload.getOrNull()?.data?.toStringUtf8()?.replace("\"", "")
             val workerAttached = if (includeWorkerCheck) workerHasPoller(executionInfo.taskQueue) else null
-            val failureInfo = executionInfo.execution.getWorkflowFailureInfo(service, temporalConfig.namespace)
+
+            val describe = service.blockingStub().describeWorkflowExecution(
+                DescribeWorkflowExecutionRequest.newBuilder()
+                    .setNamespace(temporalConfig.namespace)
+                    .setExecution(executionInfo.execution)
+                    .build()
+            )
+            val workflowStatus = describe.workflowExecutionInfo.status
+            val failureInfo = if (workflowStatus != WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_COMPLETED
+                && workflowStatus != WorkflowExecutionStatus.WORKFLOW_EXECUTION_STATUS_RUNNING) {
+                executionInfo.execution.getWorkflowFailureInfo(service, temporalConfig.namespace)
+            } else
+                null
 
             val cronSchedule = CronSchedule(
                 cron = cronScheduleRaw,

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
@@ -6,16 +6,23 @@ import io.temporal.api.failure.v1.Failure
 import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest
 import io.temporal.serviceclient.WorkflowServiceStubs
 
-fun getWorkflowFailureInfo(
+/**
+ * Retrieves detailed information about a workflow failure, if any occurred.
+ * This method analyzes the workflow execution history and identifies the source and type of failure.
+ *
+ * @param service The WorkflowServiceStubs instance used to fetch the workflow execution history.
+ * @param namespace The namespace of the workflow execution.
+ * @return A WorkflowFailureInfo object containing details about the failure, or null if no failure is found.
+ */
+fun WorkflowExecution.getWorkflowFailureInfo(
     service: WorkflowServiceStubs,
-    namespace: String,
-    execution: WorkflowExecution
+    namespace: String
 ): WorkflowFailureInfo? {
 
     val history = service.blockingStub().getWorkflowExecutionHistory(
         GetWorkflowExecutionHistoryRequest.newBuilder()
             .setNamespace(namespace)
-            .setExecution(execution)
+            .setExecution(this)
             .build()
     )
 

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
@@ -77,7 +77,7 @@ fun WorkflowExecution.getWorkflowFailureInfo(
     val canceledAttrs = canceledEvent?.workflowExecutionCanceledEventAttributes
     if (canceledAttrs != null) {
         val detailsString = canceledAttrs.details?.payloadsList
-            ?.joinToString("; ") { safeToStringUtf8(it.data) } // decode payloads safely
+            ?.joinToString("; ") { it.data.toStringUtf8() } // decode payloads safely
 
         return WorkflowFailureInfo(
             source = "canceled",

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowExecutionExtensions.kt
@@ -77,7 +77,7 @@ fun WorkflowExecution.getWorkflowFailureInfo(
     val canceledAttrs = canceledEvent?.workflowExecutionCanceledEventAttributes
     if (canceledAttrs != null) {
         val detailsString = canceledAttrs.details?.payloadsList
-            ?.joinToString("; ") { it.data.toStringUtf8() } // decode payloads safely
+            ?.joinToString("; ") { safeToStringUtf8(it.data) } // decode payloads safely
 
         return WorkflowFailureInfo(
             source = "canceled",

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowFailure.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowFailure.kt
@@ -1,0 +1,84 @@
+package gov.cdc.ocio.processingnotifications.temporal
+
+import io.temporal.api.common.v1.WorkflowExecution
+import io.temporal.api.enums.v1.EventType
+import io.temporal.api.failure.v1.Failure
+import io.temporal.api.workflowservice.v1.GetWorkflowExecutionHistoryRequest
+import io.temporal.serviceclient.WorkflowServiceStubs
+
+fun getWorkflowFailureInfo(
+    service: WorkflowServiceStubs,
+    namespace: String,
+    execution: WorkflowExecution
+): WorkflowFailureInfo? {
+
+    val history = service.blockingStub().getWorkflowExecutionHistory(
+        GetWorkflowExecutionHistoryRequest.newBuilder()
+            .setNamespace(namespace)
+            .setExecution(execution)
+            .build()
+    )
+
+    val events = history.history.eventsList
+
+    // Case 1: continued-as-new failure from previous run
+    val startEvent = events.firstOrNull { it.eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED }
+    val continuedFailure = startEvent
+        ?.workflowExecutionStartedEventAttributes
+        ?.continuedFailure
+
+    if (continuedFailure != null) {
+        return WorkflowFailureInfo(
+            source = "continued-as-new",
+            failureMessage = continuedFailure.message,
+            causeMessage = continuedFailure.cause?.message,
+            stackTrace = continuedFailure.stackTrace,
+            activityName = continuedFailure.activityFailureInfo?.activityType?.name,
+            retryState = continuedFailure.activityFailureInfo?.retryState,
+            timeoutType = continuedFailure.cause?.timeoutFailureInfo?.timeoutType
+        )
+    }
+
+    // Case 2: current run failed
+    val failedEvent = events.firstOrNull { it.eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED }
+    val failedAttrs = failedEvent?.workflowExecutionFailedEventAttributes
+    if (failedAttrs != null) {
+        val failure: Failure = failedAttrs.failure
+        return WorkflowFailureInfo(
+            source = "current-run",
+            failureMessage = failure.message,
+            causeMessage = failure.cause?.message,
+            stackTrace = failure.stackTrace
+        )
+    }
+
+    // Case 3: workflow timed out
+    val timeoutEvent = events.firstOrNull { it.eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT }
+    val timeoutAttrs = timeoutEvent?.workflowExecutionTimedOutEventAttributes
+    if (timeoutAttrs != null) {
+        return WorkflowFailureInfo(
+            source = "timed-out",
+            failureMessage = "Workflow timed out after reaching run or execution timeout.",
+            causeMessage = null,
+            stackTrace = null
+        )
+    }
+
+
+    // Case 4: workflow canceled
+    val canceledEvent = events.firstOrNull { it.eventType == EventType.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED }
+    val canceledAttrs = canceledEvent?.workflowExecutionCanceledEventAttributes
+    if (canceledAttrs != null) {
+        val detailsString = canceledAttrs.details?.payloadsList
+            ?.joinToString("; ") { it.data.toStringUtf8() } // decode payloads safely
+
+        return WorkflowFailureInfo(
+            source = "canceled",
+            failureMessage = "Workflow was canceled.",
+            causeMessage = detailsString,
+            stackTrace = null
+        )
+    }
+
+    return null // No failure, timeout, or cancellation
+}

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowFailureInfo.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/temporal/WorkflowFailureInfo.kt
@@ -1,0 +1,26 @@
+package gov.cdc.ocio.processingnotifications.temporal
+
+import io.temporal.api.enums.v1.RetryState
+import io.temporal.api.enums.v1.TimeoutType
+
+/**
+ * Represents detailed information regarding a workflow failure.
+ *
+ * @property source Specifies the source of the failure. Possible values include:
+ *                  "continued-as-new", "current-run", "timed-out", "canceled".
+ * @property failureMessage Provides the message describing the failure, if available.
+ * @property causeMessage Describes the root cause of the failure, if available.
+ * @property stackTrace Contains the stack trace related to the failure for debugging purposes, if available.
+ * @property activityName Specifies the name of the activity associated with the failure, if applicable.
+ * @property retryState Indicates the state of the retry mechanism at the time of failure, if applicable.
+ * @property timeoutType Describes the type of timeout that caused the failure, if any.
+ */
+data class WorkflowFailureInfo(
+    val source: String, // "continued-as-new", "current-run", "timed-out", "canceled"
+    val failureMessage: String?,
+    val causeMessage: String?,
+    val stackTrace: String?,
+    val activityName: String? = null,
+    val retryState: RetryState? = null,
+    val timeoutType: TimeoutType? = null
+)

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/workflow/digestcounts/UploadDigestCountsNotificationWorkflowImpl.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/workflow/digestcounts/UploadDigestCountsNotificationWorkflowImpl.kt
@@ -64,6 +64,7 @@ class UploadDigestCountsNotificationWorkflowImpl : UploadDigestCountsNotificatio
             )
         } catch (ex: ActivityFailure) {
             logger.error("Error while processing daily upload digest. The workflow may have been canceled. Error: ${ex.localizedMessage}")
+            throw ex
         } catch (ex: Exception) {
             logger.error("Error while processing daily upload digest: ${ex.localizedMessage}")
             throw ex


### PR DESCRIPTION
### Summary of changes
- The WorkflowStatus model now includes the runId, enabling more precise tracking of workflow executions.
- The inclusion of WorkflowFailureInfo allows for detailed error reporting and debugging of failed workflows.
- These changes modify the data returned by the getAllWorkflows function in WorkflowStatusService, adding runId and workflowFailureInfo to each workflow entry. Consumers of this service will need to adapt to the new data structure.

When getting "all workflows" from GraphQL you now get:
<img width="965" height="514" alt="Screenshot 2025-08-07 at 7 49 31 PM" src="https://github.com/user-attachments/assets/3cc977b2-6805-4cfc-be90-658f2646833f" />
> NOTE: There is a new structure, `workflowFailureInfo` that contains the details of the failure.
