### PR TITLE
PHDO-872 - Workflow subscription validation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,4 +23,4 @@ jobs:
           docker compose -f docker-compose.playwright.yml run --rm --quiet-pull playwright
       - name: Stop Services
         run: |
-          docker compose -f docker-compose.local.yml down
+          docker compose -f docker-compose.ci.yml down

--- a/pstatus-notifications-workflow-ktor/src/main/kotlin/service/NotificationSubscriptionService.kt
+++ b/pstatus-notifications-workflow-ktor/src/main/kotlin/service/NotificationSubscriptionService.kt
@@ -27,6 +27,13 @@ class NotificationSubscriptionService: KoinComponent {
     private val workflowEngine by inject<WorkflowEngine>()
 
     fun subscribeTopErrors(subscription: WorkflowSubscriptionForDataStreams): WorkflowSubscriptionResult {
+        require(subscription.dataStreamIds.size == 1) {
+            "Expected exactly one data stream ID, but found ${subscription.dataStreamIds.size}"
+        }
+        require(subscription.dataStreamRoutes.size == 1) {
+            "Expected exactly one data stream route, but found ${subscription.dataStreamRoutes.size}"
+        }
+
         val workflow = workflowEngine.setupWorkflow(
             "Determines the count of the top 5 errors that have occurred for this data stream in the time range provided.",
             WorkflowTaskQueue.TOP_ERRORS.toString(),

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotificati-613e3-g-errors-no-data-stream-id-or-data-stream-route-no-data-stream-id-or-route
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotificati-613e3-g-errors-no-data-stream-id-or-data-stream-route-no-data-stream-id-or-route
@@ -1,0 +1,1 @@
+[{"message":"Expected exactly one data stream ID, but found 0","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-multiple-data-stream-ids-multiple-data-stream-ids
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-multiple-data-stream-ids-multiple-data-stream-ids
@@ -1,0 +1,1 @@
+[{"message":"Expected exactly one data stream ID, but found 2","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-multiple-data-stream-routes-multiple-data-stream-routes
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-multiple-data-stream-routes-multiple-data-stream-routes
@@ -1,0 +1,1 @@
+[{"message":"Expected exactly one data stream route, but found 2","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-no-data-stream-id-no-data-stream-id
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-no-data-stream-id-no-data-stream-id
@@ -1,0 +1,1 @@
+[{"message":"Expected exactly one data stream ID, but found 0","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-no-data-stream-route-no-data-stream-route
+++ b/test/playwright/tests/__snapshot__/subscribeDataStreamTopErrorsNotification.spec.ts/GraphQL-subscribeDataStreamTopErrorsNotification-subscribing-errors-no-data-stream-route-no-data-stream-route
@@ -1,0 +1,1 @@
+[{"message":"Expected exactly one data stream route, but found 0","locations":[],"path":["subscribeDataStreamTopErrorsNotification"],"extensions":{"classification":"BadRequestException"}}]

--- a/test/playwright/tests/subscribeDataStreamTopErrorsNotification.spec.ts
+++ b/test/playwright/tests/subscribeDataStreamTopErrorsNotification.spec.ts
@@ -66,22 +66,6 @@ test.describe('GraphQL subscribeDataStreamTopErrorsNotification', () => {
         await notificationHelper.validateWebhookIsCalledForToken(token, { timeout: 70_000 });
     });
 
-    test('subscribing to a generic data stream via email', {tag: "@slow"}, async ({ notificationHelper, dataGenerator }) => {
-        const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
-        const subscription = dataGenerator.createSubscriptionInput({
-            emailAddresses: [subscriptionEmail],
-            cronSchedule: "@every 10s",
-            dataStreamIds: [],
-            dataStreamRoutes: [],
-            jurisdictions: []
-        });
-
-        const subscriptionResponse = await notificationHelper.subscribeDataStreamTopErrorsNotificationAndValidate(subscription);
-        subscriptions.push(subscriptionResponse.subscriptionId!.toString())
-        
-        await notificationHelper.validateEmailIsSent(subscriptionEmail, "PHDO TOP ERRORS NOTIFICATION");
-    });
-
     test('subscribing with multiple emails', async ({ notificationHelper, dataGenerator }) => {
         const subscriptionEmail1 = `subscribeDataStreamTopErrorsNotification-multiple-emails-1@test.com`;
         const subscriptionEmail2 = `subscribeDataStreamTopErrorsNotification-multiple-emails-2@test.com`;
@@ -137,5 +121,71 @@ test.describe('GraphQL subscribeDataStreamTopErrorsNotification', () => {
             const res = await gql.subscribeDataStreamTopErrorsNotification({ subscription }, { failOnEmptyData: false }) as unknown as GraphQLErrorResponse;
             expect(JSON.stringify(res.errors)).toMatchSnapshot("invalid-email-format");
         });
-    });
+
+        test('no data stream id or data stream route', async ({ gql, dataGenerator}) => {
+            const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
+            const subscription = dataGenerator.createSubscriptionInput({
+                emailAddresses: [subscriptionEmail],
+                cronSchedule: "@every 10s",
+                dataStreamIds: [],
+                dataStreamRoutes: [],
+            });
+
+            const res =  await gql.subscribeDataStreamTopErrorsNotification({ subscription }, {failOnEmptyData: false}) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("no-data-stream-id-or-route");
+        });
+
+        test('no data stream id', async ({ gql, dataGenerator}) => {
+            const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
+            const subscription = dataGenerator.createSubscriptionInput({
+                emailAddresses: [subscriptionEmail],
+                cronSchedule: "@every 10s",
+                dataStreamIds: [],
+                dataStreamRoutes: ["dataStreamRoute"],
+            });
+
+            const res =  await gql.subscribeDataStreamTopErrorsNotification({ subscription }, {failOnEmptyData: false}) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("no-data-stream-id");
+        });
+
+        test('no data stream route', async ({ gql, dataGenerator}) => {
+            const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
+            const subscription = dataGenerator.createSubscriptionInput({
+                emailAddresses: [subscriptionEmail],
+                cronSchedule: "@every 10s",
+                dataStreamIds: ["dataStreamId"],
+                dataStreamRoutes: [],
+            });
+
+            const res =  await gql.subscribeDataStreamTopErrorsNotification({ subscription }, {failOnEmptyData: false}) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("no-data-stream-route");
+        });
+        
+        test('multiple data stream ids', async ({ gql, dataGenerator}) => {
+            const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
+            const subscription = dataGenerator.createSubscriptionInput({
+                emailAddresses: [subscriptionEmail],
+                cronSchedule: "@every 10s",
+                dataStreamIds: ["stream1", "stream2"],
+                dataStreamRoutes: ["dataStreamRoute"],
+            });
+
+            const res =  await gql.subscribeDataStreamTopErrorsNotification({ subscription }, {failOnEmptyData: false}) as unknown as GraphQLErrorResponse;
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("multiple-data-stream-ids");
+        });
+
+        test('multiple data stream routes', async ({ gql, dataGenerator}) => {
+            const subscriptionEmail = `subscribeDataStreamTopErrorsNotification-datastream-generic@test.com`;
+            const subscription = dataGenerator.createSubscriptionInput({
+                emailAddresses: [subscriptionEmail],
+                cronSchedule: "@every 10s",
+                dataStreamIds: ["stream1"],
+                dataStreamRoutes: ["dataStreamRoute1", "dataStreamRoute2"],
+            });
+            
+            const res =  await gql.subscribeDataStreamTopErrorsNotification({ subscription }, {failOnEmptyData: false}) as unknown as GraphQLErrorResponse
+            expect(JSON.stringify(res.errors)).toMatchSnapshot("multiple-data-stream-routes");
+        });
+
+    })
 });


### PR DESCRIPTION
### Summary of changes
- Adds validation to ensure that exactly one data stream ID and one data stream route are provided when subscribing to top errors. This prevents unexpected behavior when the system expects a single data stream for this particular workflow.